### PR TITLE
Optional modifier that allows for updating diff values in-game, with backup and restore features

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ A CSV named `{header}_metrics_{timestamp}.csv`, containing a row per song includ
 - `--cache`: point at a specific cache file, instead of most recent for the header
 - `--modify_game`: Will take in either `CalcTier` or `RemapDiff`. If either are supplied will update values in-game with the calculation of choice. if nothing is supplied, will not update values.
 
+**Note: When modifying values in game, you MUST SCAN SONGS for the new metadata to work.**
+
 ---
 
 ## 4. The Difficulty Formula

--- a/README.md
+++ b/README.md
@@ -221,5 +221,13 @@ Solo sections (and optionally star power, if enabled in the config) are shaded o
 - `--header` / `--cache`: pick which library/cache to pull from
 - `--out-dir`: where to save the PNGs (defaults to `render_dir` in `config.py`)
 
+## 6. Restoring difficulties from backup
+
+`restore.py` restores your difficulties from a backup built when doing build.py. It is useful if you don't want the new modified difficulties, you can restore to your OG backup (separated by HEADER at the time). Creates one backup that can be constantly updated. Does not modify songs that already exist in the backup.
+
+**Optional Arguments:**
+- `--header`: Pick which library to restore from
+- `--path`: Pull a backup from a specific path. This is specifically the parent folder (so it would be `cache` as a default example)
+
 ## License
 **MIT** - see LICENSE for details.

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ Libraries required are **pandas, numpy, tqdm, mido, and matplotlib** - everythin
 
 To use the tool setup **config** and run these in order:
 
-1. **Build** - scan a library and save everything into a cache file
-2. **Analyze** - turn that cache into a CSV including song metadata and calculated metrics, one row per song - this step applies the difficulty formula
+1. **Build** - scan a library and save everything into a cache file. Creates a backup of original difficulties
+2. **Analyze** - turn that cache into a CSV including song metadata and calculated metrics, one row per song - this step applies the difficulty formula. With a parameter, allows you to adjust the values in-game based on which difficulty calculation you prefer.
 3. **Render** - output a PNG graph of metrics over time for one or more specific songs based on an ID from the CSV
-
+4. **Restore** - Restores all difficulties to normal from the backup built by Build.
 ---
 
 ## 1. Setup: `config.py`
@@ -59,10 +59,13 @@ Under `RENDER_DEFAULT` and `RENDER_THEMES`, you can tweak how `render.py's` PNGs
 
 By default this will run on the `SEARCH_PATH` & `HEADER` set in the config.
 
+Additionally, this builds a backup of your original difficulties if you'd like to restore them at any point for any reason.
+
 **Outputs:**
 
 - A `{header}_cache_{timestamp}.pkl` file, the main output used by Analyze and Render
 - A `{header}_errors_{timestamp}.csv` file, only generated if some songs failed to parse, this lists which file failed and why (e.g. missing guitar track, corrupt midi file)
+- A `{header}_BackupData.csv` file, which is a back up that stores all difficulties that were found at the time of building
 - A console summary: how many songs had a `song.ini`, how many had no readable guitar chart, how many errored, and how many made it into the cache
 
 **Optional arguments:**
@@ -73,7 +76,9 @@ By default this will run on the `SEARCH_PATH` & `HEADER` set in the config.
 
 ## 3. Analyzing a cache
 
-`analyze.py` loads the most recent cache for your config's `HEADER`, computes difficulty metrics for every song in it, and writes a CSV. This is the main output for browsing the library.
+`analyze.py` loads the most recent cache for your config's `HEADER`, computes difficulty metrics for every song in it, and writes a CSV. This is the main output for browsing the library. 
+
+Optionally will adjust your `song.ini`'s diff_guitar parameters to the calc of your choice
 
 **Outputs:**
 
@@ -87,6 +92,7 @@ A CSV named `{header}_metrics_{timestamp}.csv`, containing a row per song includ
 
 - `--header`: analyze a different library's most recent cache
 - `--cache`: point at a specific cache file, instead of most recent for the header
+- `--modify_game`: Will take in either `CalcTier` or `RemapDiff`. If either are supplied will update values in-game with the calculation of choice. if nothing is supplied, will not update values.
 
 ---
 

--- a/analyze.py
+++ b/analyze.py
@@ -14,7 +14,7 @@ timestamp of generation
 song.ini metadata (name/artist/charter/difficulty/release) 
 forumla difficulty metrics (duration, NPS/VPS metrics, D, remapped & calculated tier)
 """
-
+import configparser
 import argparse
 import pathlib
 
@@ -22,6 +22,7 @@ import pandas as pd
 import tqdm
 
 import config
+from functions import ini_updater
 from functions import cache as cache_mod
 from functions import density, formula
 
@@ -33,6 +34,10 @@ def song_row(entry, gen_on):
         return None
 
     difficulty = formula.calc_diff(metrics)
+
+    ini_path = pathlib.Path(f"{entry["song_path"]}/song.ini")
+    
+    ini_updater.update_ini_value(ini_path, "diff_guitar", difficulty["CalcTier"])
 
     return {
         'Code': entry['code'],
@@ -87,6 +92,7 @@ def main():
     parser = argparse.ArgumentParser(description="Compute metrics from a note stream cache.")
     parser.add_argument('--header', default=None, help="run identifier to look up (default: config.HEADER)")
     parser.add_argument('--cache', default=None, help="explicit cache path (overrides header lookup)")
+    parser.add_argument('--modify_game', action="store_true", help="Modify the in-game intensities for ease of use")
     args = parser.parse_args()
 
     analyze(cache_path=args.cache, header=args.header)

--- a/analyze.py
+++ b/analyze.py
@@ -14,7 +14,6 @@ timestamp of generation
 song.ini metadata (name/artist/charter/difficulty/release) 
 forumla difficulty metrics (duration, NPS/VPS metrics, D, remapped & calculated tier)
 """
-import configparser
 import argparse
 import pathlib
 

--- a/analyze.py
+++ b/analyze.py
@@ -28,7 +28,7 @@ from functions import density, formula
 
 LEAD_COLS = ['Code', 'CacheGeneratedAt']
 
-def song_row(entry, gen_on):
+def song_row(entry, gen_on, diff_type=None):
     metrics = density.calc_metrics(entry['notes'])
     if metrics is None:
         return None
@@ -36,8 +36,10 @@ def song_row(entry, gen_on):
     difficulty = formula.calc_diff(metrics)
 
     ini_path = pathlib.Path(f"{entry["song_path"]}/song.ini")
-    
-    ini_updater.update_ini_value(ini_path, "diff_guitar", difficulty["CalcTier"])
+
+    if diff_type is not None:
+        if diff_type == "CalcTier" or diff_type == "RemapDiff":
+            ini_updater.update_ini_value(ini_path, "diff_guitar", difficulty[diff_type])
 
     return {
         'Code': entry['code'],
@@ -48,7 +50,7 @@ def song_row(entry, gen_on):
     }
 
 # run the analysis - loading from selected/default cache
-def analyze(cache=None, cache_path=None, header=None, out_dir=None):
+def analyze(cache=None, cache_path=None, header=None, out_dir=None, diff_type=None):
     header = header or config.HEADER
 
     if cache is None:
@@ -62,7 +64,7 @@ def analyze(cache=None, cache_path=None, header=None, out_dir=None):
     skipped = 0
 
     for entry in tqdm.tqdm(cache['songs'].values(), desc="Computing metrics", unit="song"):
-        row = song_row(entry, gen_on)
+        row = song_row(entry, gen_on, diff_type)
         if row is None:
             skipped += 1
             continue
@@ -92,10 +94,10 @@ def main():
     parser = argparse.ArgumentParser(description="Compute metrics from a note stream cache.")
     parser.add_argument('--header', default=None, help="run identifier to look up (default: config.HEADER)")
     parser.add_argument('--cache', default=None, help="explicit cache path (overrides header lookup)")
-    parser.add_argument('--modify_game', action="store_true", help="Modify the in-game intensities for ease of use")
+    parser.add_argument('--modify_game', default=None, help="Choose which type of calc you'd like to use for in-game.")
     args = parser.parse_args()
 
-    analyze(cache_path=args.cache, header=args.header)
+    analyze(cache_path=args.cache, header=args.header, diff_type=args.modify_game)
 
 
 if __name__ == '__main__':

--- a/build.py
+++ b/build.py
@@ -16,6 +16,7 @@ ini is parsed first on purpose - need to pass down tags for mid sp/solo
 
 import argparse
 import csv
+from pathlib import Path
 
 import config
 from parsers import chart_parser, ini_parser, mid_parser
@@ -60,7 +61,7 @@ def build_cache(search_path=None, header=None, out_dir=None):
 
     note_index = build_note_index(search_path, mult_notes, errors)
 
-    print("Joining metadata")
+    print("Joining metadata and building difficulty backup")
     songs = {}
     no_guitar = 0
 
@@ -83,6 +84,8 @@ def build_cache(search_path=None, header=None, out_dir=None):
             'notes': stream['notes'],
             'spans': stream['spans'],
         }
+
+        backup_data(song_path, ini_row["Difficulty"], f"caches/{header}_BackupData.csv")
 
     codes = cache_mod.assign_codes(songs.keys())
     for song_path, code in codes.items():
@@ -126,6 +129,25 @@ def build_cache(search_path=None, header=None, out_dir=None):
 
     return built
 
+BACKUP_COLUMNS = ["song_path", "diff_guitar"]
+
+def backup_data(song_path, original_diff, backup_csv):
+    backup_csv = Path(backup_csv)
+    is_new = not backup_csv.exists()
+
+    if not is_new:
+        with open(backup_csv, "r", newline="", encoding="utf-8") as f:
+            existing_paths = {row["song_path"] for row in csv.DictReader(f)}
+        if str(song_path) in existing_paths:
+            return
+
+    with open(backup_csv, "a", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=BACKUP_COLUMNS)
+
+        if is_new:
+            writer.writeheader()
+        row = {"song_path": str(song_path), "diff_guitar": str(original_diff)}
+        writer.writerow(row)
 
 def main():
     parser = argparse.ArgumentParser(description="Build a notestream cache from a song library.")

--- a/config.py
+++ b/config.py
@@ -22,10 +22,10 @@ from datetime import datetime
 # ------
 
 # Library to scan. set here or override on the command line with --search-path.
-SEARCH_PATH = r"C:\Users\reyd0\Documents\Clone Hero\PlayerData\Songs" # edit to your library path before running Build
+SEARCH_PATH = r"C:\Users\user\Documents\Clone Hero\Songs" # edit to your library path before running Build
 
 # Identifies this run. Overridable with --header.
-HEADER = "MainCache" # edit to title your cache before running Build/Analyze/Render
+HEADER = "FullTest" # edit to title your cache before running Build/Analyze/Render
 
 #------------------------------
 # RENDER output directory - DON'T NEED TO EDIT, these dump to the tool's folder

--- a/config.py
+++ b/config.py
@@ -22,11 +22,10 @@ from datetime import datetime
 # ------
 
 # Library to scan. set here or override on the command line with --search-path.
-SEARCH_PATH = r"C:\Users\user\Documents\Clone Hero\Songs" # edit to your library path before running Build
+SEARCH_PATH = r"C:\Users\reyd0\Documents\Clone Hero\PlayerData\Songs" # edit to your library path before running Build
 
 # Identifies this run. Overridable with --header.
-HEADER = "Test" # edit to title your cache before running Build/Analyze/Render
-
+HEADER = "MainCache" # edit to title your cache before running Build/Analyze/Render
 
 #------------------------------
 # RENDER output directory - DON'T NEED TO EDIT, these dump to the tool's folder

--- a/functions/ini_updater.py
+++ b/functions/ini_updater.py
@@ -1,0 +1,15 @@
+import configparser
+
+def update_ini_value(ini_path, key, value, encoding="utf-8-sig"):
+    config = configparser.ConfigParser(strict=False)
+    config.read(ini_path, encoding=encoding)
+
+    section_name = next((s for s in config.sections() if s.lower() == "song"), None)
+
+    if section_name is None:
+        raise KeyError(f"No [song] section found in {ini_path}")
+
+    config[section_name][key] = str(value)
+
+    with open(ini_path, "w", encoding=encoding) as f:
+        config.write(f)

--- a/restore.py
+++ b/restore.py
@@ -3,7 +3,6 @@ RESTORE - Restores values from the backup created upon building. Uses your HEADE
 """
 
 import argparse
-import pathlib
 
 import config
 import csv

--- a/restore.py
+++ b/restore.py
@@ -1,0 +1,39 @@
+"""
+RESTORE - Restores values from the backup created upon building. Uses your HEADER to find the file
+"""
+
+import argparse
+import pathlib
+
+import config
+import csv
+from functions import ini_updater
+
+def restore_from_backup(Header=None, CachePath=None):
+    if (CachePath is None):
+        CachePath = config.CACHE_DIR
+
+    if (Header is None):
+        Header = config.HEADER
+
+    file_name = f"{Header}_BackupData.csv"
+    file_path = f"{CachePath}/{file_name}"
+
+    with open(file_path, "r", newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            song_path = row["song_path"]
+            difficulty = row["diff_guitar"]
+
+            ini_updater.update_ini_value(f"{song_path}/song.ini", "diff_guitar", difficulty)
+
+def main():
+    parser = argparse.ArgumentParser(description="Restore metrics based on original difficulty data")
+    parser.add_argument('--header', default=None, help="run identifier to look up (default: config.HEADER)")
+    parser.add_argument('--path', default=None, help="File path where backup is stored")
+    args = parser.parse_args()
+
+    restore_from_backup(args.header, args.path)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Hi, not sure how necessary this is but I felt like it would help me quite a bit. (this is also my first forked PR)

I love this concept so I modified the code to allow for updating these values in-game so people don't have to look up on a spreadsheet.

It allows for:
- Updating in-game values based on the specified calc type (CalcTier, or RemapDiff)
- Restoring values to a backup if you want to (creates a backup on the build step). Using restore.py

It's also completely optional and works as normal if you just don't supply --modify_game in the parameters on the analyze step.

Just to note: In order for the difficulties to update properly you do need to scan songs afterwards. If you see "UPDATING_METADATA" that means it worked. If you do not see that, the song data did not get updated. 

Did my best to keep the code clean! If there are issues please let me know I can fix it up!

