### PR TITLE
fix song.ini files being dropped on % and multi-line loading_phrase

### DIFF
--- a/parsers/ini_parser.py
+++ b/parsers/ini_parser.py
@@ -5,7 +5,6 @@ also captures star-power pitch disambiguation for .mid: (multiplier_note / star_
 Source tables (gh/rb/ch) and html-tag cleanup regex live here
 """
 
-import configparser
 import pathlib
 import re
 
@@ -67,18 +66,37 @@ def _parse_int_tag(raw):
         return None
 
 
-def ini_parse(file):
-    config = configparser.ConfigParser(strict=False)
+# no declared encoding - usually utf-8, cp1252 from older tools, utf-16 if saved from notepad
+def _read_text(file):
+    raw = file.read_bytes()
+    if raw.startswith((b'\xff\xfe', b'\xfe\xff')):
+        return raw.decode('utf-16', errors='replace')
     try:
-        config.read(file, encoding='utf-8-sig')
+        return raw.decode('utf-8-sig')
     except UnicodeDecodeError:
-        config.read(file, encoding='cp1252')
+        return raw.decode('cp1252', errors='replace')
 
-    section = 'song' if config.has_section('song') else (config.sections()[0] if config.sections() else None)
-    if section is None:
-        raise ValueError(f"No sections found in {file}")
 
-    ini = config[section]
+# key = value parse, same as chart_parser.parse_chart
+# not configparser - it chokes on % and line breaks in loading_phrase
+# [section] lines skipped (only ever [song]), keys lowercased, last dupe wins
+def parse_ini(file):
+    ini = {}
+    for line in _read_text(file).splitlines():
+        line = line.strip()
+        if not line or line[0] in ';#[':
+            continue
+        if '=' not in line:
+            continue
+        key, value = line.split('=', 1)
+        ini[key.strip().lower()] = value.strip()
+    return ini
+
+
+def ini_parse(file):
+    ini = parse_ini(file)
+    if not ini:
+        raise ValueError(f"No key = value metadata found in {file}")
 
     # clean up tags & fix missing data, hard codes for malformed or missing
     name = DETAG.sub("", ini.get('name', 'unk'))


### PR DESCRIPTION
## Problem

`ini_parser.ini_parse` hands the whole `song.ini` to `configparser`, which parses every line before any value is read. Two kinds of perfectly normal files get rejected, and because `ini_loop` catches the exception, the song just lands in the errors CSV and never makes it into the cache:

1. **`%` in `name`, `artist` or `charter`** – `configparser` has `%(...)s` interpolation on by default, so a song called `100% Fun` raises `InterpolationSyntaxError`.
2. **A line break inside `loading_phrase`** – the continuation line has no `=`, so the file fails with `ParsingError`. Rock Band tips are long and some exporters emit real newlines in them. Worse, if the continuation happens to start with `[`, `configparser` treats it as a new section and every key after it (`diff_guitar`, `multiplier_note`) silently ends up in the wrong section instead of erroring.

Repro for (2): take any `song.ini` and put a newline in the middle of the `loading_phrase` value.

## Fix

Replace `configparser` with a small manual parser, same approach as `chart_parser.parse_chart`: split each line on the first `=`, lowercase the key, skip blank/comment/`[section]` lines and anything without `=`. Nothing about the tip text can veto the file any more, and `%` is just a character.

Decoding is done up front with a fallback chain that never raises: UTF-16 if there's a BOM, then UTF-8 (BOM stripped), then cp1252 with `errors='replace'`. Previously a cp1252 file containing one of the five bytes that codepage doesn't define (`0x81 0x8D 0x8F 0x90 0x9D`) would still throw on the fallback path.

## Verification

- Ran the old and new `ini_parse` over 84 Rock Band 2 `song.ini` files and compared every output field: 0 differences.
- Synthetic cases that previously raised now parse with the correct `Difficulty` / `MultiplierNote`: embedded LF, CR and CRLF in `loading_phrase`, a `[Chorus]` continuation line, `%` in `name`/`artist`, UTF-16 with BOM, undefined cp1252 bytes.
- No changes to the output dict shape, so `build.py` and the cache format are untouched.
