### PR TITLE
Add Serve - browse the metrics spreadsheet in a browser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ caches/
 instrument_scan.py
 *.xlsx
 *.xlsx#
+.venv/
+songs/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,148 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+Fretwork computes difficulty scores for 5-fret rhythm-game charts (Guitar/Co-op/Rhythm/Bass/Keys at Easy/Medium/Hard/Expert) from `song.ini` + `notes.chart` / `notes.mid` files. The formula and calibration are documented in `Methodology.md`; user-facing usage is in `README.md`. Read those before changing metrics or calibration constants.
+
+## Commands
+
+Plain Python 3 scripts, no packaging config, no test suite, no linter. Always work inside the project virtualenv at `.venv/` (gitignored); never install into or run against the system interpreter.
+
+```
+python3 -m venv .venv
+source .venv/bin/activate          # Windows: .venv\Scripts\activate
+pip install -r requirements.txt
+```
+
+If `python3 -m venv` fails with an ensurepip error (Debian/Ubuntu and WSL without `python3-venv`), use `uv` instead; it needs no system packages and is what created the venv on the WSL dev box:
+
+```
+uv venv .venv
+uv pip install --python .venv/bin/python -r requirements.txt
+```
+
+A uv-created venv has no `pip` inside it, so add packages with `uv pip install --python .venv/bin/python <pkg>`. Either way, run the scripts with the venv active or as `.venv/bin/python build.py`.
+
+The three entry points run in order and are glued together by `config.HEADER` (see Architecture):
+
+```
+python build.py [--search-path DIR] [--header NAME]
+python analyze.py [--header NAME] [--cache FILE.pkl] [--diff-mode CalcTier|RemapDiff|Restore] [--xlsx-levels X|EX|EMHX|ALL]
+python render.py CODE [CODE ...] [--codes-file FILE] [--header NAME] [--cache FILE.pkl] [--out-dir DIR]
+```
+
+`serve.py` is an optional fourth entry point that browses an existing metrics `.xlsx` in a browser instead of Excel. Clicking a row renders that chart's graph on demand; columns have Excel-style filter dropdowns and can be hidden individually (remembered in `localStorage`). It reads the spreadsheet, not the cache, so `analyze.py` must have run first; the cache is loaded lazily only when a graph is clicked. Stdlib `http.server` plus pandas, binds `127.0.0.1` only, nothing added to `requirements.txt`:
+
+```
+python serve.py [--header NAME] [--xlsx FILE.xlsx] [--cache FILE.pkl] [--port 8000] [--no-bootstrap]
+```
+
+Bootstrap 5.3 supplies the base CSS. It is downloaded once into `CACHE_DIR` as `bootstrap-<version>.min.css` (gitignored with the rest of `caches/`) and served same-origin from `/bootstrap.css`, so the page never contacts a CDN at view time and works offline after the first run. If the fetch fails or `--no-bootstrap` is passed, the page inlines `FALLBACK_CSS` instead, which covers layout plus the `d-none` / `dropdown-menu.show` state classes the page's JS toggles. There is no JS framework and no Bootstrap JS; interaction is plain DOM code that toggles Bootstrap's own classes.
+
+### `web/` is the viewer, and only the viewer
+
+Root `serve.py` is a thin entry point in the same shape as the other three: docstring, one orchestration function, `main()`. Everything else lives in `web/`, a namespace package (no `__init__.py`, matching `functions/` and `parsers/`). It is named `web/` rather than `serve/` because a `serve/` directory beside `serve.py` loses to the module in Python's import resolution and would be silently unimportable.
+
+| Module | Responsibility |
+|---|---|
+| `web/frames.py` | Reads the metrics `.xlsx` into JSON-safe rows. The only pandas importer. |
+| `web/boot.py` | Builds the JSON payload the page reads, and escapes `</` in it. |
+| `web/page.py` | Substitutes `index.html`'s four placeholders in one regex pass. |
+| `web/bootstrap.py` | Bootstrap fetch/cache plus `FALLBACK_CSS`, its own fallback branch. |
+| `web/assets.py` | Locates `static/` relative to `__file__` and loads it at startup. |
+| `web/graph.py` | `GraphRenderer`: lazy cache load, PNG memo, render on demand. |
+| `web/handler.py` | `MetricsHandler`: routing and response writing only. |
+| `web/server.py` | `MetricsServer`: carries the handler's dependencies. |
+| `web/banner.py` | The startup and shutdown terminal output. |
+
+The page's markup, CSS and 15 ES modules live under `web/static/`, served from an in-memory dict built by globbing at startup. Keys never derive from a request path, so traversal is impossible by construction rather than by guard. Server data reaches the JS through a `<script type="application/json" id="fw-boot">` island that `boot.js` parses once and re-exports; `boot.py` escapes `</` so spreadsheet text can never close the tag. All mutable page state lives in one exported `state` object because ES module imports are read-only bindings.
+
+Two things must stay off the server's startup import path: matplotlib (via `functions/plot.py`) and openpyxl (via `functions/xlsx_format.py`). `GraphRenderer` imports plot inside its method bodies, and `web/boot.py` keeps a local copy of `SCALED_COLS` rather than importing `xlsx_format` for it.
+
+Before running Build, `config.SEARCH_PATH` must point at a real song library (the committed value is a Windows placeholder). Build on a ~3k-song library takes several minutes; midi parsing dominates.
+
+`--diff-mode CalcTier|RemapDiff` and `config.DIFF_WRITE_MODE` **write to the user's `song.ini` files**. `Restore` rewrites them from the backup CSV and skips analysis entirely. Treat these as destructive to user data.
+
+There are no automated tests. To sanity-check a change to parsing or metrics, build, analyze, and inspect the terminal summary / xlsx / error CSV against a small local library. The convention is a gitignored `songs/` folder at the repo root holding a handful of song folders copied from a real library (song folders contain copyrighted audio and must never be committed):
+
+```
+python build.py --search-path songs --header Local
+python analyze.py --header Local
+```
+
+## Architecture
+
+### Three-stage pipeline keyed by HEADER + timestamp
+
+`build.py` -> cache `.pkl` -> `analyze.py` -> metrics `.xlsx`; `render.py` reads the same cache to draw PNGs. Every output is named `{header}_{kind}_{timestamp}.{ext}` via `functions/timestamp.py`, and `config.KIND_DIRS` routes each kind to a folder (`caches/` for cache, errors CSV, and backup; `metrics/` for xlsx; `renders/` for PNG). Analyze and Render locate the *newest* cache for a header by parsing the timestamp out of the filename (`timestamp.latest_output`), so filename format is load-bearing. Analyze reuses the cache's timestamp for its xlsx so the pair can be matched.
+
+All of these outputs are gitignored (`*.pkl`, `*.csv`, `*.xlsx`, `*.png`, `caches/`). The `.xlsx` and `.png` files under `metrics/` and `renders/` are committed examples that were force-added; don't expect new outputs to show up in `git status`.
+
+### The cache is the data contract
+
+The pickled cache shape is documented at the top of `functions/cache.py`. Everything downstream (analyze, render, curves, density) consumes `notes = {'time_ms': ndarray, 'lanes': ndarray uint8}` plus `spans = {'star_power': [(ms, ms)], 'solo': [...]}` per (song, instrument, level). Both parsers must emit exactly that shape.
+
+**Lane encoding**: one `uint8` bitmask per note timestamp. Bits 0-4 are GRBYO frets, bit 7 is open. Bits 5-6 are reserved (chart tap/force modifiers) and unused. Strum/HOPO/tap state is deliberately discarded by both parsers.
+
+**Retrieval codes** (`04821993XG`): 8 digits from a SHA1 of the resolved song folder path (with linear probing on collision), then a level letter (E/M/H/X) and an instrument letter (G/C/R/B/K). Assigned in `cache.assign_codes` at build time and stored in `cache['codes']`. Render accepts codes without leading zeros.
+
+### Parsers (`parsers/`)
+
+Build runs them in a fixed order for a reason: `ini_parser` first, because `multiplier_note`/`star_power_note` from `song.ini` tells `mid_parser` whether MIDI pitch 103 means star power (legacy) or solo. Then `mid_parser`, then `chart_parser`. When a song folder has both formats, **chart wins** (`build.build_note_index`).
+
+- `parsers/timing.py` holds the shared tempo-map and tick-to-ms conversion used by both formats. Use `ticks_to_ms` (vectorized) for note arrays and `tick_to_ms` for the handful of span endpoints.
+- `.chart` distinguishes level by section-name prefix (`ExpertSingle`, `HardDoubleBass`); `.mid` distinguishes level by pitch block within one track per instrument (`instruments.MID_PITCH_BASE`). Star power and solos are per-section in `.chart` but track-wide (shared across levels) in `.mid`.
+- Songs that fail to parse are appended to an `errors` list as `(path, ErrorType, message)` and written to the errors CSV; a single bad file never aborts a build. Non-fatal data loss (unclosed solos, malformed SP, unknown-channel legacy opens) is tallied in `dropped` counters instead.
+
+### `functions/instruments.py` is the single source of truth
+
+Every instrument/level table lives there: canonical keys and iteration order, `.mid` track names, `.chart` section names (with legacy fallbacks), pitch bases, `song.ini` `diff_*` tags, code suffixes, open-note support, xlsx sheet grouping, and display labels. Adding an instrument means adding it here and adding a calibration group in `functions/formula.py`; nothing else should hardcode instrument names.
+
+### `functions/difficulty.py` holds the shared difficulty block
+
+`entry_difficulty(entry)` computes D/N/V/COV for the entry's own level plus the Expert-anchored `RemapDiff`/`CalcTier`. `render.py` and `web/graph.py` both call it; it was duplicated verbatim between them before.
+
+### `functions/labels.py` holds every human-facing string
+
+The abbreviated keys (`pNPS`, `medVPS`, `COV`, `DurationS`) are the data contract: they come out of `density.calc_metrics` and `formula.calc_nvcov`, flow through the dataframes in `analyze.py`, and become the xlsx headers. Nothing keyed off a column name should change. `labels.py` maps those keys to readable text at display time only, via `COLUMN_LABELS`, `COLUMN_HELP` (tooltips), `TIME_COLUMNS` (seconds shown as m:ss), and `UI` (interface wording for `serve.py`). `label()` falls back to the raw key, so a new metric column degrades gracefully instead of raising.
+
+Only `serve.py` consumes it today. The xlsx headers and the render header are deliberately still raw keys, since changing them would alter committed example outputs and anything downstream that reads the spreadsheet by column name. Wiring either one up is a display-layer change through this module, not a rename in the pipeline.
+
+### Metrics pipeline (`functions/density.py` -> `functions/formula.py`)
+
+`density.window_arrays` slides a 1000 ms window in 250 ms steps from t=0 to the last note and produces raw NPS (note timestamps per window) and VPS (fret-change per window; see `fret_var`) samples. `calc_metrics` reduces those to peak/avg/median/std. `formula.calc_nvcov` turns them into `D = N * V * COV` and is instrument-agnostic.
+
+**Expert anchoring**: `D` is computed per level, but `RemapDiff` (0-6 bins, per calibration group) and `CalcTier` (uncapped log tier) are computed once per (song, instrument) from the **Expert** level's D via `formula.anchor_remap_tier`, and that pair is shown on every E/M/H/X row. If an instrument has no Expert chart, both are `None`/NaN. This is because `song.ini` only has one `diff_*` tag per instrument. Guitar, Co-op, and Rhythm share the `guitar` calibration group.
+
+The bin edges and CalcTier constants in `formula.py` are mirrored as tables in `Methodology.md`; update both together.
+
+### Render path (`functions/curves.py` -> `functions/plot.py`)
+
+Render recomputes from the cache rather than reading stored metrics. `curves.calc_curves` reuses `density.window_arrays`, converts to rates, and applies a zero-phase EMA (`TAU_MS = 2000`). The plotted "D" line is `sqrt(nps * vps)`, an approximation for display that omits COV, while the header's `D` value comes from the real formula. Appearance comes entirely from `config.RENDER_DEFAULT` + `config.RENDER_THEMES`; `plot.py` uses the Agg backend and never opens a window.
+
+### `song.ini` backup and write-back (`functions/ini_updater.py`)
+
+Build **always** appends new songs to `caches/{header}_BackupData.csv` (append-only, deduplicated by `song_path`, one column per `diff_*` tag) regardless of config. It never writes to `song.ini`. Analyze's write modes and Restore both go through `update_ini_values`, which patches matching `key = value` lines inside the `[song]` section in place, appends missing keys at the end of the section, and preserves the file's original encoding (utf-8 / utf-8-sig / utf-16 / cp1252) and newline style. Don't replace it with `configparser`; `song.ini` files routinely contain `%` and other characters that break it, which is also why `ini_parser.parse_ini` is hand-rolled.
+
+## Conventions worth knowing
+
+- `config.py` is user-edited configuration (paths, header, theme), not library code. The committed `SEARCH_PATH`/`HEADER` values are placeholders. `instrument_scan.py` is gitignored local scratch.
+- `Difficulty` of `'-1'` (string in cache, int in xlsx) is the sentinel for "no `diff_*` tag in song.ini". `xlsx_format.BLANK_PREDICATES` keeps sentinels out of the color scales.
+- `analyze.COLUMN_ORDER` defines xlsx column order; `xlsx_format.DEFAULT_HIDDEN_COLS` lists the diagnostic columns that are dropped unless `config.EXTRA_METRICS` is True. Excel sheet names are truncated to 31 chars.
+- Song identity everywhere is the resolved absolute folder path (`song_path`), which is also the join key between the ini table, note streams, backup CSV, and codes.
+- Terminal progress uses `tqdm`; keep long loops wrapped so multi-minute builds stay observable.
+
+## Working with the repo
+
+Hosted at `github.com/Staycation44/fretwork`, single maintainer. `main` is the only long-lived branch. There is no CI, no branch protection, and no `.github/` directory, so nothing gates a merge except the maintainer and a manual pipeline run.
+
+- **Feature work goes on a staging branch** named for the feature (`five-fret-staging`, `EMHX-Staging`), branched from `main`. Before merging, merge `main` *into* the staging branch to absorb anything that landed meanwhile, then merge the staging branch into `main` with a merge commit, preferably via a GitHub PR. Delete the branch after it lands. Every feature branch so far has been deleted post-merge.
+- **Merge commits only.** History is never rebased or squashed; WIP commits and self-merges are left as-is.
+- **Small changes go straight to `main`.** README edits, one-line fixes, and calibration tweaks (e.g. "updated remap bins") are committed directly.
+- **Releases are lightweight tags on `main`** (`v0.6.1` through `v0.8`), applied after the merge lands. There is no version constant in the code; the only "bump version" commit edited the README. Numbering is informal.
+- **Outside contributions arrive as fork PRs** and are typically reworked after merging (PR #1 added a standalone restore script that was later folded into `analyze.py`).
+- **Commit messages are short and informal**, one line, describing what changed. Larger refactors are sometimes bundled into a single commit.
+- **Example outputs are tracked despite the gitignore.** The `.xlsx` in `metrics/` and `.png` in `renders/` were force-added; if you regenerate them, `git add -f` the new files and remove the stale ones in the same commit. Never commit caches, backup CSVs, or a real library's metrics.
+- **Before merging parser or metrics changes**, run build, analyze, and render against a small song folder and compare the terminal summary and error CSV against the previous run, since there is no automated test to catch regressions.

--- a/README.md
+++ b/README.md
@@ -15,13 +15,15 @@ To use the tool setup **config** and run these in order:
 2. **Analyze** - Turn Build's cache into an .xlsx spreadsheet including song metadata and calculated metrics for every song/instrument combo. 
 Optionally, applies calculated difficulty to `song.ini` files for use in-game, or restores them back to their originals from the backup
 3. **Render** - Output a PNG graph of metrics over time for one or more song/instrument combos based on a retrieval code from the spreadsheet
+4. **Serve** *(optional)* - Browse the spreadsheet in a browser instead of Excel, with per-column filters and click-a-row-to-see-its-graph
 
 ## Index <!-- omit in toc -->
 - [1. Setup your Config](#1-setup-your-config)
 - [2. Building a cache](#2-building-a-cache)
 - [3. Analyzing a cache](#3-analyzing-a-cache)
 - [4. Rendering song graphs](#4-rendering-song-graphs)
-- [5. Fixes/Extension Ideas](#5-fixesextension-ideas)
+- [5. Browsing in a browser](#5-browsing-in-a-browser)
+- [6. Fixes/Extension Ideas](#6-fixesextension-ideas)
 - [License](#license)
 
 ---
@@ -148,7 +150,37 @@ Solo sections (and optionally star power, if enabled in the config) are shaded o
 
 ---
 
-## 5. Fixes/Extension Ideas
+## 5. Browsing in a browser
+
+`python serve.py`
+
+`serve.py` serves the most recent metrics spreadsheet for your header as a local web page, so you can sort and filter without opening Excel. It reads the **spreadsheet**, so run Analyze first.
+
+Open **http://localhost:8000** once it starts. It binds `127.0.0.1` only, so nothing outside your machine can reach it. On WSL the URL works in a Windows browser as-is.
+
+**What the page does:**
+
+- **Sort** by clicking a column header, click again to flip direction. Opens sorted by D, hardest first
+- **Filter** any column from the caret next to its name - a checkbox list for things like Part or Remap Tier, a min/max box for wide numeric columns like D or Length. Value counts reflect your other active filters
+- **Search** song, artist, charter or source from the box in the toolbar
+- **Click a row** to render that chart's graph and see it in a lightbox - the same PNG `render.py` produces, written to your render folder. The copy icon on a Code cell copies the retrieval code instead
+- **Columns** button hides any column you do not want, remembered in your browser
+- Friendly column names throughout, with the metric definitions on hover. Unrated songs (`diff_*` of -1) show a dash rather than the raw number
+
+**Optional arguments:**
+- `--header` / `--xlsx`: pick which library's spreadsheet to serve
+- `--cache`: explicit cache path, used for the on-demand graphs
+- `--out-dir`: where rendered PNGs are written (defaults to `render_dir` in `config.py`)
+- `--port`: something other than 8000
+- `--no-bootstrap`: skip the Bootstrap download and use the built-in styles
+
+**Note:** the page's CSS comes from Bootstrap, downloaded once into your cache folder the first time you run Serve and then served from your own machine. After that first run it works offline. If the download fails it falls back to built-in styles and still works.
+
+Stop the server with Ctrl+C.
+
+---
+
+## 6. Fixes/Extension Ideas
 **Fixes:**
 - Midi files misbehaving - *possibly parser drift / file corrruption/truncation?*
 

--- a/functions/difficulty.py
+++ b/functions/difficulty.py
@@ -1,0 +1,26 @@
+"""
+DIFFICULTY - the per-entry difficulty block shared by render and the web viewer
+
+D/N/V/COV come from the entry's own level, while RemapDiff and CalcTier anchor
+to the song's Expert chart - see Methodology.md.
+"""
+
+from functions import density, formula
+
+
+# None when the entry has no usable notes; RemapDiff/CalcTier are None when the
+# instrument has no Expert chart to anchor against.
+def entry_difficulty(entry):
+    metrics = density.calc_metrics(entry['notes'])
+    if metrics is None:
+        return None
+
+    expert_notes = entry.get('expert_notes')
+    expert_metrics = density.calc_metrics(expert_notes) if expert_notes is not None else None
+    anchor_remap, anchor_tier = formula.anchor_remap_tier(expert_metrics, entry['instrument'])
+
+    return {
+        **formula.calc_nvcov(metrics),
+        'RemapDiff': anchor_remap,
+        'CalcTier': anchor_tier,
+    }

--- a/functions/labels.py
+++ b/functions/labels.py
@@ -1,0 +1,169 @@
+"""
+LABELS - human-facing display strings for the abbreviated column/metric keys
+
+The short keys ('pNPS', 'medVPS', 'COV', 'DurationS') stay exactly as they are
+everywhere in the data path - density.calc_metrics output, formula.calc_nvcov
+output, the dataframes in analyze.py, and the xlsx headers. Nothing keyed off a
+column name has to change. This module is the single place that maps one of
+those keys to something a person can read, applied only at display time.
+
+    COLUMN_LABELS  short label for a column header
+    COLUMN_HELP    one-line explanation, for tooltips / hover text
+    UI             interface strings for serve.py's page
+
+Anything not in COLUMN_LABELS falls back to the raw key, so a new metric column
+shows up readable-ish instead of blowing up - see label().
+
+Formula terms are spelled out in Methodology.md; the help text here is the short
+version of the same thing.
+"""
+
+# NPS/VPS get spelled out - "notes/sec" and "fret changes/sec" are what they
+# actually measure, and that reads better than the acronym in a column header
+COLUMN_LABELS = {
+    # identity / metadata
+    'Code':       'Code',
+    'Song Title': 'Song',
+    'Artist':     'Artist',
+    'Level':      'Level',
+    'Type':       'Part',
+    'Charter':    'Charter',
+    'Release':    'Source',
+    'Official':   'Official',
+
+    # shape of the chart
+    'NoteCount':  'Notes',
+    'DurationS':  'Length',
+
+    # difficulty
+    'Difficulty': 'Original Tier',
+    'D':          'Difficulty (D)',
+    'RemapDiff':  'Remap Tier',
+    'CalcTier':   'Calc Tier',
+
+    # note density
+    'pNPS':       'Peak notes/sec',
+    'aNPS':       'Avg notes/sec',
+    'medNPS':     'Median notes/sec',
+    'stdNPS':     'Std dev notes/sec',
+
+    # fret variability
+    'pVPS':       'Peak changes/sec',
+    'aVPS':       'Avg changes/sec',
+    'medVPS':     'Median changes/sec',
+    'stdVPS':     'Std dev changes/sec',
+
+    # formula components
+    'N':          'Note factor (N)',
+    'V':          'Variability factor (V)',
+    'COV':        'Consistency (CoV)',
+}
+
+COLUMN_HELP = {
+    'Code':       'Retrieval code: 8-digit song hash, then level (E/M/H/X) and instrument (G/C/R/B/K). Pass it to render.py.',
+    'Song Title': 'Song name from song.ini.',
+    'Artist':     'Artist from song.ini.',
+    'Level':      'Charted difficulty level: Easy, Medium, Hard or Expert.',
+    'Type':       'Which part this row is: Lead, Co-op, Rhythm, Bass or Keys.',
+    'Charter':    'Who charted the song, from song.ini.',
+    'Release':    'Release or source pack. Officials are matched against the tables in sources/.',
+    'Official':   'True when the source pack is an official Guitar Hero or Rock Band release.',
+
+    'NoteCount':  'Total notes in this chart. Frets played together count as one note, same as the games score it.',
+    'DurationS':  'Time from t=0 to the last note.',
+
+    'Difficulty': 'The diff_* tier already in song.ini. -1 means the tag is missing.',
+    'D':          'Calculated difficulty, D = N x V x CoV. The main output. Higher is harder, uncapped.',
+    'RemapDiff':  'D binned to 0-6, calibrated per instrument so the spread matches official tiers. From the Expert chart only.',
+    'CalcTier':   'Log-scaled tier, one step per 0.44 increase in ln(D) above 7.6. Uncapped, so hard customs reach 10+. From the Expert chart only.',
+
+    'pNPS':       'Busiest one-second window, in notes per second.',
+    'aNPS':       'Notes per second across the whole chart, including rests.',
+    'medNPS':     'Median one-second window. Resistant to a single spike.',
+    'stdNPS':     'Spread of note density across the chart.',
+
+    'pVPS':       'Busiest one-second window of fret movement.',
+    'aVPS':       'Fret changes per second across the whole chart.',
+    'medVPS':     'Median one-second window of fret movement.',
+    'stdVPS':     'Spread of fret movement across the chart.',
+
+    'N':          'Note-density term: cube root of median x average x peak notes/sec.',
+    'V':          'Variability term: cube root of median x average x peak changes/sec.',
+    'COV':        'Interaction term, 1 or higher. Rewards charts whose difficulty is uneven.',
+}
+
+# ---------------------------------------------------------------------
+# "no data" sentinels
+# ---------------------------------------------------------------------
+# Difficulty's -1 has two origins that mean the same thing to a reader:
+#   - the diff_* tag is absent, and ini_parser falls back to '-1'
+#   - the tag is present but set to -1, which is the unrated convention
+#     (the GH3 pack does this: every diff_* is -1 while diff_band is set)
+# xlsx_format already treats -1 as blank for fill/color-scale purposes; this is
+# the same idea for any human-facing surface.
+MISSING_VALUES = {
+    'Difficulty': (-1,),
+}
+
+MISSING_TEXT = '\u2014'  # em dash
+
+MISSING_HELP = {
+    'Difficulty': 'No difficulty rating in song.ini (diff_* is -1 or absent)',
+    'RemapDiff':  'No Expert chart for this instrument to anchor the tier to',
+    'CalcTier':   'No Expert chart for this instrument to anchor the tier to',
+}
+
+
+# True for None/NaN or a column's own "unrated" sentinel
+def is_missing(column, value):
+    if value is None:
+        return True
+    return value in MISSING_VALUES.get(column, ())
+
+
+# columns holding a duration in seconds - shown as m:ss, still sorted as a number
+TIME_COLUMNS = ('DurationS',)
+
+
+def label(column):
+    return COLUMN_LABELS.get(column, column)
+
+
+def help_text(column):
+    return COLUMN_HELP.get(column, '')
+
+
+# interface strings for serve.py's page, kept here so the wording lives in one file
+UI = {
+    'title':            'Fretwork',
+    'subtitle':         'library difficulty',
+    'search':           'Filter by song, artist, charter or source...',
+    'clear_one':        'Clear 1 filter',
+    'clear_many':       'Clear {n} filters',
+    'count':            '{shown} of {total} songs',
+    'filter_tip':       'Filter this column',
+    'sort_tip':         'Sort by this column',
+    'code_tip':         'Click to see the difficulty graph, shift-click to copy the code',
+    'select_all':       'Select all',
+    'select_none':      'Clear',
+    'value_search':     'Search values',
+    'range_apply':      'Apply',
+    'range_clear':      'Clear',
+    'range_hint':       '{label} between min and max',
+    'range_min':        'min {v}',
+    'range_max':        'max {v}',
+    'rendering':        'Rendering graph...',
+    'render_failed':    'Could not render this chart. Is the matching cache loaded?',
+    'copied':           'Copied {code}',
+    'no_data':          'No songs match these filters.',
+
+    # row / graph interaction
+    'row_tip':          'Click for the difficulty graph',
+    'copy_code_tip':    'Copy this code',
+    'close_tip':        'Close (Esc)',
+
+    # column chooser
+    'columns':          'Columns',
+    'columns_tip':      'Choose which columns to show',
+    'columns_reset':    'Show all',
+}

--- a/render.py
+++ b/render.py
@@ -28,7 +28,8 @@ import tqdm
 import config
 from functions import cache as cache_mod
 from functions import curves as curves_mod
-from functions import density, formula, ini_updater, plot, timestamp
+from functions import difficulty as difficulty_mod
+from functions import ini_updater, plot, timestamp
 
 
 def render_codes(codes, cache=None, cache_path=None, header=None, out_dir=None,
@@ -62,19 +63,7 @@ def render_codes(codes, cache=None, cache_path=None, header=None, out_dir=None,
             print(f"  [skip] {entry['code']}: no curve data")
             continue
 
-        difficulty = None
-        if with_difficulty:
-            metrics = density.calc_metrics(entry['notes'])
-            if metrics is not None:
-                expert_notes = entry.get('expert_notes')
-                expert_metrics = density.calc_metrics(expert_notes) if expert_notes is not None else None
-                anchor_remap, anchor_tier = formula.anchor_remap_tier(expert_metrics, entry['instrument'])
-
-                difficulty = {
-                    **formula.calc_nvcov(metrics),
-                    'RemapDiff': anchor_remap,
-                    'CalcTier': anchor_tier,
-                }
+        difficulty = difficulty_mod.entry_difficulty(entry) if with_difficulty else None
 
         original_diff = original_diffs.get(entry['song_path'], {}).get(entry['instrument'])
 

--- a/serve.py
+++ b/serve.py
@@ -1,0 +1,77 @@
+"""
+SERVE - browse a metrics spreadsheet in a browser instead of Excel
+
+Loads the newest metrics .xlsx for a header and serves it as a sortable,
+filterable table on localhost. Clicking a row renders that song's graph on
+demand - same PNG render.py produces, written to RENDER_DIR and cached in
+memory for the life of the process.
+
+    python serve.py
+    python serve.py --header FullTest --port 8080
+    python serve.py --xlsx metrics/Local_metrics_09072026-1022.xlsx
+
+Stdlib http.server - no web framework, nothing added to requirements.txt.
+Binds 127.0.0.1 only. WSL2 forwards localhost, so the URL opens in a Windows
+browser as-is.
+
+Bootstrap 5.3 supplies the CSS. It is downloaded once into CACHE_DIR and then
+served same-origin from /bootstrap.css, so the page has no CDN dependency at
+view time and keeps working offline after the first run. --no-bootstrap skips
+it and falls back to the built-in styles.
+
+Reads the spreadsheet, not the cache - run analyze.py first. The cache is only
+touched (lazily) the first time a graph is requested.
+
+The page itself lives in web/ - see web/static/ for its markup and scripts.
+"""
+
+import argparse
+
+import config
+from web import assets, banner, boot, bootstrap, frames, page
+from web.graph import GraphRenderer
+from web.server import MetricsServer
+
+
+def serve(header=None, xlsx_path=None, cache_path=None, port=8000, out_dir=None,
+          use_bootstrap=True):
+    header = header or config.HEADER
+    bootstrap_css = bootstrap.ensure_bootstrap(use_bootstrap)
+
+    xlsx_path, sheets = frames.load_frames(header, xlsx_path)
+    total = sum(len(df) for df in sheets.values())
+    source = f"{xlsx_path.name}  -  {total} rows  -  {', '.join(sheets)}"
+
+    body = page.render_page(
+        f"Fretwork - {header}", source, bootstrap_css,
+        boot.boot_json(frames.frames_payload(sheets)))
+
+    httpd = MetricsServer(
+        port, body, assets.load_static(), bootstrap_css,
+        GraphRenderer(header, cache_path, out_dir))
+
+    with httpd:
+        banner.print_startup(xlsx_path, sheets, total, bootstrap_css, port)
+        try:
+            httpd.serve_forever()
+        except KeyboardInterrupt:
+            banner.print_stopped()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Serve a metrics spreadsheet as a local web page.")
+    parser.add_argument('--header', default=None, help="run identifier to look up (default: config.HEADER)")
+    parser.add_argument('--xlsx', default=None, help="explicit metrics .xlsx (overrides header lookup)")
+    parser.add_argument('--cache', default=None, help="explicit cache path, used for on-demand graphs")
+    parser.add_argument('--out-dir', default=None, help="PNG output directory for rendered graphs")
+    parser.add_argument('--port', type=int, default=8000, help="localhost port (default 8000)")
+    parser.add_argument('--no-bootstrap', action='store_true',
+                        help="skip the Bootstrap fetch and use the built-in styles")
+    args = parser.parse_args()
+
+    serve(header=args.header, xlsx_path=args.xlsx, cache_path=args.cache,
+          port=args.port, out_dir=args.out_dir, use_bootstrap=not args.no_bootstrap)
+
+
+if __name__ == '__main__':
+    main()

--- a/web/assets.py
+++ b/web/assets.py
@@ -1,0 +1,42 @@
+"""
+ASSETS - locates and reads the page's bundled static files
+
+Paths resolve from this file, not the working directory, so serve.py works
+from anywhere. Required files are read at startup so a partial checkout fails
+before the socket binds.
+"""
+
+import pathlib
+
+STATIC_DIR = pathlib.Path(__file__).resolve().parent / 'static'
+
+# glob -> content type; each file's URL path comes from its path under STATIC_DIR
+STATIC_GLOBS = (
+    ('js/*.js', 'text/javascript; charset=utf-8'),
+    ('css/*.css', 'text/css; charset=utf-8'),
+)
+
+REQUIRED = ('index.html', 'js/main.js', 'css/app.css')
+
+
+def read_text(name):
+    return (STATIC_DIR / name).read_text(encoding='utf-8')
+
+
+def check_present():
+    missing = [n for n in REQUIRED if not (STATIC_DIR / n).is_file()]
+    if missing:
+        raise FileNotFoundError(
+            f"missing static file(s) under {STATIC_DIR}: {', '.join(missing)}")
+
+
+# URL path -> (bytes, content type), built by walking STATIC_DIR at startup.
+# Keys never come from a request, so path traversal is impossible by construction.
+def load_static():
+    check_present()
+    served = {}
+    for pattern, content_type in STATIC_GLOBS:
+        for path in sorted(STATIC_DIR.glob(pattern)):
+            url = '/static/' + path.relative_to(STATIC_DIR).as_posix()
+            served[url] = (path.read_bytes(), content_type)
+    return served

--- a/web/banner.py
+++ b/web/banner.py
@@ -1,0 +1,19 @@
+"""
+BANNER - the terminal output around serve_forever
+"""
+
+from web.bootstrap import BOOTSTRAP_VERSION
+
+
+def print_startup(xlsx_path, frames, total, bootstrap_css, port):
+    style = (f"Bootstrap {BOOTSTRAP_VERSION} (served locally)"
+             if bootstrap_css else "built-in fallback")
+    print(f"\nServing {xlsx_path}")
+    print(f"    {total} rows across {len(frames)} sheet(s): {', '.join(frames)}")
+    print(f"    styles: {style}")
+    print(f"\n    http://localhost:{port}\n")
+    print("Ctrl+C to stop\n")
+
+
+def print_stopped():
+    print("\nStopped\n")

--- a/web/boot.py
+++ b/web/boot.py
@@ -1,0 +1,34 @@
+"""
+BOOT - assembles the JSON payload the page's JavaScript reads on load
+
+Delivered as one <script type="application/json"> island rather than inlined
+into the script, so spreadsheet text can never be parsed as code.
+"""
+
+import json
+
+from functions import labels as labels_mod
+
+# Mirrors xlsx_format.SCALED_COLS. Kept local on purpose: importing that module
+# would pull openpyxl onto the server's startup path to save four strings.
+SCALED_COLS = ['Difficulty', 'D', 'RemapDiff', 'CalcTier']
+
+
+def boot_payload(frames_data):
+    return {
+        'data': frames_data,
+        'scaled': SCALED_COLS,
+        'labels': labels_mod.COLUMN_LABELS,
+        'help': labels_mod.COLUMN_HELP,
+        'ui': labels_mod.UI,
+        'timecols': list(labels_mod.TIME_COLUMNS),
+        'missing': {k: list(v) for k, v in labels_mod.MISSING_VALUES.items()},
+        'missText': labels_mod.MISSING_TEXT,
+        'missHelp': labels_mod.MISSING_HELP,
+    }
+
+
+# Escaping every "<" keeps spreadsheet text from closing the script tag or
+# entering its double-escaped state. A valid JSON escape, parsed back unchanged.
+def boot_json(frames_data):
+    return json.dumps(boot_payload(frames_data)).replace('<', '\\u003c')

--- a/web/bootstrap.py
+++ b/web/bootstrap.py
@@ -1,0 +1,96 @@
+"""
+BOOTSTRAP - fetches and caches the Bootstrap stylesheet, with a fallback
+
+Cached under CACHE_DIR so the served page never contacts a CDN and keeps
+working offline after the first run. FALLBACK_CSS lives here because it is
+exactly the branch taken when the fetch returns nothing.
+"""
+
+import http.client
+import pathlib
+import urllib.error
+import urllib.request
+
+import config
+
+BOOTSTRAP_VERSION = '5.3.8'
+BOOTSTRAP_URL = (f"https://cdn.jsdelivr.net/npm/bootstrap@{BOOTSTRAP_VERSION}"
+                 f"/dist/css/bootstrap.min.css")
+BOOTSTRAP_MIN_BYTES = 100_000  # sanity floor - a captive-portal HTML page is way under this
+
+FALLBACK_CSS = """<style>
+  :root { --bs-body-bg:#1a1a1c; --bs-body-color:#eaeaea; --bs-border-color:#34343a;
+          --bs-tertiary-bg:#232326; --bs-secondary-color:#9a9aa2;
+          --bs-font-monospace:ui-monospace,SFMono-Regular,Consolas,monospace; }
+  * { box-sizing:border-box; }
+  body { margin:0; background:var(--bs-body-bg); color:var(--bs-body-color);
+         font:13px/1.45 ui-sans-serif,system-ui,"Segoe UI",Roboto,sans-serif; }
+  .d-none { display:none !important; }
+  .d-flex { display:flex; } .flex-wrap { flex-wrap:wrap; } .flex-fill { flex:1; }
+  .align-items-center { align-items:center; } .align-items-baseline { align-items:baseline; }
+  .gap-2 { gap:.5rem; } .mt-2 { margin-top:.5rem; } .mb-2 { margin-bottom:.5rem; }
+  .mb-0 { margin-bottom:0; } .ms-auto { margin-left:auto; } .w-auto { width:auto; }
+  .px-3 { padding-left:1rem; padding-right:1rem; } .pt-3 { padding-top:1rem; }
+  .pb-2 { padding-bottom:.5rem; } .p-2 { padding:.5rem; }
+  .border-bottom { border-bottom:1px solid var(--bs-border-color); }
+  .bg-body { background:var(--bs-body-bg); }
+  .h6 { font-size:15px; } .fw-semibold { font-weight:600; }
+  .small, .form-text { font-size:11px; }
+  .text-secondary, .form-text { color:var(--bs-secondary-color); }
+  .form-control, .form-control-sm { background:var(--bs-tertiary-bg); color:var(--bs-body-color);
+    border:1px solid var(--bs-border-color); border-radius:6px; padding:5px 9px; font-size:13px; outline:none; }
+  .form-control:focus { border-color:#b71fb7; }
+  .btn { background:var(--bs-tertiary-bg); color:var(--bs-body-color); cursor:pointer;
+    border:1px solid var(--bs-border-color); border-radius:6px; padding:5px 10px; font-size:12px; }
+  .btn:hover { border-color:#b71fb7; }
+  .btn-primary, .btn.active { background:#b71fb7; border-color:#b71fb7; color:#fff; }
+  .btn-link { background:none; border:0; }
+  .btn-group { display:flex; } .btn-group .btn { border-radius:0; }
+  .btn-group .btn:first-child { border-radius:6px 0 0 6px; }
+  .btn-group .btn:last-child { border-radius:0 6px 6px 0; }
+  table { border-collapse:collapse; width:100%; }
+  th, td { border-bottom:1px solid #26262b; text-align:left; }
+  tbody tr:hover td { background:#26262c; }
+  .badge { display:inline-block; padding:2px 8px; font-size:11px; }
+  .rounded-pill { border-radius:9px; }
+  .dropdown-menu { display:none; background:var(--bs-tertiary-bg);
+    border:1px solid var(--bs-border-color); border-radius:8px; }
+  .dropdown-menu.show { display:block; }
+  .shadow { box-shadow:0 10px 30px rgba(0,0,0,.55); }
+  .form-check { position:relative; }
+  .form-check-input { position:absolute; left:4px; top:5px; }
+  .input-group { display:flex; align-items:center; gap:4px; }
+  .input-group .form-control { width:100%; }
+</style>"""
+
+
+def bootstrap_path():
+    return pathlib.Path(config.CACHE_DIR) / f"bootstrap-{BOOTSTRAP_VERSION}.min.css"
+
+
+# returns the cached CSS bytes, downloading once if needed, or None if unavailable
+def ensure_bootstrap(enabled=True):
+    if not enabled:
+        return None
+
+    path = bootstrap_path()
+    if path.is_file() and path.stat().st_size >= BOOTSTRAP_MIN_BYTES:
+        return path.read_bytes()
+
+    print(f"Fetching Bootstrap {BOOTSTRAP_VERSION} (one time) ...", end='', flush=True)
+    try:
+        with urllib.request.urlopen(BOOTSTRAP_URL, timeout=20) as resp:
+            data = resp.read()
+    except (urllib.error.URLError, OSError, TimeoutError,
+            http.client.HTTPException) as exc:
+        print(f" failed ({exc}) - using built-in styles")
+        return None
+
+    if len(data) < BOOTSTRAP_MIN_BYTES:
+        print(" failed (unexpected response) - using built-in styles")
+        return None
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
+    print(f" cached {len(data) // 1024} KB -> {path}")
+    return data

--- a/web/frames.py
+++ b/web/frames.py
@@ -1,0 +1,31 @@
+"""
+FRAMES - reads a metrics .xlsx into JSON-safe rows
+
+The only module here that imports pandas.
+"""
+
+import json
+import pathlib
+
+import pandas as pd
+
+from functions import timestamp
+
+
+def load_frames(header, xlsx_path=None):
+    if xlsx_path is None:
+        xlsx_path = timestamp.latest_output('metrics', header, ext='xlsx')
+    xlsx_path = pathlib.Path(xlsx_path)
+    return xlsx_path, pd.read_excel(xlsx_path, sheet_name=None)
+
+
+# to_json is the round trip that turns NaN into null and numpy scalars into
+# plain numbers; df.values.tolist() would emit bare NaN and invalid JSON.
+def frames_payload(frames):
+    return {
+        name: {
+            'columns': list(df.columns),
+            'rows': json.loads(df.to_json(orient='values')),
+        }
+        for name, df in frames.items()
+    }

--- a/web/graph.py
+++ b/web/graph.py
@@ -1,0 +1,71 @@
+"""
+GRAPH - renders one chart's PNG on demand, caching within the process
+
+Owns the note cache and the PNG memo, so two renderers cannot split them.
+"""
+
+import pathlib
+import threading
+
+import config
+from functions import cache as cache_mod
+from functions import difficulty, timestamp
+
+
+class GraphRenderer:
+    """Renders retrieval codes to PNG bytes, loading the cache once, lazily."""
+
+    def __init__(self, header, cache_path=None, out_dir=None):
+        self.header = header
+        self.cache_path = cache_path
+        self.out_dir = out_dir or config.RENDER_DIR
+        self._cache = None
+        self._diffs = None
+        self._png = {}
+        self._lock = threading.Lock()
+
+    # None when the code is unknown or the chart has no curve data.
+    def png(self, code):
+        if code in self._png:
+            return self._png[code]
+        with self._lock:
+            if code in self._png:
+                return self._png[code]
+            data = self._render(code)
+            if data is not None:
+                self._png[code] = data
+            return data
+
+    def _render(self, code):
+        # plot pulls matplotlib, so it stays off the startup path
+        from functions import curves as curves_mod
+        from functions import plot
+
+        entries, _missing = cache_mod.entries_by_code(self.cache(), [code])
+        if not entries:
+            return None
+
+        entry = entries[0]
+        song_curves = curves_mod.calc_curves(entry['notes'])
+        if song_curves is None:
+            return None
+
+        png_path = plot.render_song(
+            entry, song_curves, difficulty.entry_difficulty(entry),
+            original_diff=self.original_diff(entry), out_dir=self.out_dir)
+        return pathlib.Path(png_path).read_bytes()
+
+    def cache(self):
+        if self._cache is None:
+            path = self.cache_path or timestamp.latest_output(
+                'cache', self.header, ext='pkl')
+            self._cache = cache_mod.load(path)
+        return self._cache
+
+    # The backed-up song.ini tier shown in the render header.
+    def original_diff(self, entry):
+        from functions import ini_updater
+
+        if self._diffs is None:
+            self._diffs = ini_updater.load_backup_diffs(self.header, config.CACHE_DIR)
+        return self._diffs.get(entry['song_path'], {}).get(entry['instrument'])

--- a/web/handler.py
+++ b/web/handler.py
@@ -1,0 +1,73 @@
+"""
+HANDLER - routes GET requests and writes responses
+
+Dependencies arrive on self.server, the stdlib's own injection point, so this
+class stays module-level and constructor-free.
+"""
+
+import http.server
+import pathlib
+import urllib.parse
+
+HTML_TYPE = 'text/html; charset=utf-8'
+TEXT_TYPE = 'text/plain; charset=utf-8'
+CSS_TYPE = 'text/css; charset=utf-8'
+
+GRAPH_PREFIX = '/graph/'
+PAGE_PATHS = ('/', '/index.html')
+
+
+class MetricsHandler(http.server.BaseHTTPRequestHandler):
+
+    def do_GET(self):
+        path = urllib.parse.urlparse(self.path).path
+
+        if path in PAGE_PATHS:
+            return self._send(200, HTML_TYPE, self.server.body)
+        if path == '/bootstrap.css':
+            return self._send_bootstrap()
+        if path in self.server.static:
+            data, content_type = self.server.static[path]
+            return self._send(200, content_type, data)
+        if path.startswith(GRAPH_PREFIX):
+            return self._send_graph(path)
+        return self._send(404, TEXT_TYPE, b'not found')
+
+    def _send_bootstrap(self):
+        css = self.server.bootstrap_css
+        if css is None:
+            return self._send(404, TEXT_TYPE, b'bootstrap not cached')
+        return self._send(200, CSS_TYPE, css, cache_seconds=86400)
+
+    # isalnum() is the only guard the code needs: it rejects dots and slashes,
+    # so a traversal attempt can never reach the renderer.
+    def _send_graph(self, path):
+        code = pathlib.PurePosixPath(path).stem
+        if not code.isalnum():
+            return self._send(400, TEXT_TYPE, b'bad code')
+        try:
+            data = self.server.graphs.png(code)
+        except FileNotFoundError as exc:
+            return self._send(503, TEXT_TYPE, str(exc).encode())
+        if data is None:
+            return self._send(404, TEXT_TYPE, b'no graph for that code')
+        return self._send(200, 'image/png', data)
+
+    # A viewer that navigates away mid-response is normal, not an error.
+    def _send(self, status, content_type, data, cache_seconds=None):
+        try:
+            self.send_response(status)
+            self.send_header('Content-Type', content_type)
+            self.send_header('Content-Length', str(len(data)))
+            if cache_seconds:
+                self.send_header('Cache-Control', f'max-age={cache_seconds}')
+            self.end_headers()
+            self.wfile.write(data)
+        except (BrokenPipeError, ConnectionResetError):
+            pass
+
+    # Keep the terminal quiet during browsing; only graph requests are worth a line.
+    def log_message(self, fmt, *args):
+        first = str(args[0]) if args else ''
+        if GRAPH_PREFIX in first:
+            super().log_message(fmt, *args)

--- a/web/page.py
+++ b/web/page.py
@@ -1,0 +1,31 @@
+"""
+PAGE - fills index.html's placeholders and returns the response body
+
+One regex pass rather than chained replaces, so a value that happens to
+contain __TOKEN__ text is never rewritten by a later substitution.
+"""
+
+import html
+import re
+
+from web import assets, bootstrap
+
+_PLACEHOLDER = re.compile(r'__([A-Z]+)__')
+
+BOOTSTRAP_LINK = '<link rel="stylesheet" href="/bootstrap.css">'
+
+
+def bootstrap_head(bootstrap_css):
+    return BOOTSTRAP_LINK if bootstrap_css else bootstrap.FALLBACK_CSS
+
+
+def render_page(title, source, bootstrap_css, boot_json):
+    values = {
+        'TITLE': html.escape(title),
+        'SOURCE': html.escape(source),
+        'BOOTSTRAP': bootstrap_head(bootstrap_css),
+        'BOOT': boot_json,
+    }
+    template = assets.read_text('index.html')
+    body = _PLACEHOLDER.sub(lambda m: values[m.group(1)], template)
+    return body.encode('utf-8')

--- a/web/server.py
+++ b/web/server.py
@@ -1,0 +1,20 @@
+"""
+SERVER - the HTTP server, carrying the handler's dependencies
+"""
+
+import http.server
+
+from web.handler import MetricsHandler
+
+BIND_HOST = '127.0.0.1'
+
+
+class MetricsServer(http.server.ThreadingHTTPServer):
+    """Threading server whose attributes are what MetricsHandler reads."""
+
+    def __init__(self, port, body, static, bootstrap_css, graphs):
+        self.body = body
+        self.static = static
+        self.bootstrap_css = bootstrap_css
+        self.graphs = graphs
+        super().__init__((BIND_HOST, port), MetricsHandler)

--- a/web/static/css/app.css
+++ b/web/static/css/app.css
@@ -1,0 +1,51 @@
+  /* project-specific only - Bootstrap handles layout, controls, table, dropdown, modal */
+  :root { --fw-accent:#b71fb7; --fw-code:#4aa3e0; }
+  [data-bs-theme="dark"] { --bs-primary:#b71fb7; --bs-link-color-rgb:74,163,224; }
+  body { font-size:13px; }
+  .fw-accent { color:var(--fw-accent); }
+  .btn-check:checked + .btn, .btn-fw.active { background:var(--fw-accent); border-color:var(--fw-accent); color:#fff; }
+  .fw-head { position:sticky; top:0; z-index:1030; }
+  .fw-wrap { overflow:auto; height:calc(100vh - 118px); }
+  .fw-wrap table { margin-bottom:0; }
+  .fw-wrap thead th { position:sticky; top:0; z-index:2; background:var(--bs-tertiary-bg);
+    padding:0; font-size:11px; text-transform:uppercase; letter-spacing:.4px; white-space:nowrap; }
+  .fw-wrap thead th .thw { display:flex; align-items:center; gap:2px; padding:6px 6px 6px 10px; }
+  .fw-wrap thead th .lbl { cursor:pointer; user-select:none; flex:1; }
+  .fw-wrap thead th.sorted .lbl, .fw-wrap thead th.filtered .flt { color:var(--fw-accent); }
+  .fw-wrap thead th.filtered { background:#2b2233; }
+  .fw-wrap td { padding:5px 10px; white-space:nowrap; vertical-align:middle; }
+  td.num { text-align:right; font-variant-numeric:tabular-nums; }
+  td.code { font-family:var(--bs-font-monospace); color:var(--fw-code); cursor:pointer; }
+  td.code:hover { text-decoration:underline; }
+  td.title { max-width:320px; overflow:hidden; text-overflow:ellipsis; }
+  /* level + difficulty colors carried over from xlsx_format.py so the two views read alike */
+  .lvl { color:#1a1a1c; font-weight:600; }
+  .Easy{background:#c6efce}.Medium{background:#bdd7ee}.Hard{background:#ffe5b4}.Expert{background:#ffc7ce}
+  .scale { border-radius:4px; padding:1px 6px; color:#1a1a1c; font-weight:600; }
+  .blank { color:var(--bs-secondary-color); }
+  #dd { position:fixed; width:255px; max-height:min(420px,70vh); overflow:auto;
+        z-index:1050; text-transform:none; letter-spacing:normal; font-size:12px; }
+  #dd .list { max-height:250px; overflow:auto; }
+  #dd .form-check { margin-bottom:0; padding:2px 4px 2px 1.6rem; border-radius:4px; }
+  #dd .form-check:hover { background:var(--bs-tertiary-bg); }
+  #dd .form-check-label { display:flex; width:100%; gap:8px; cursor:pointer; }
+  #dd .form-check-label .v { overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+  #dd .form-check-label .n { margin-left:auto; color:var(--bs-secondary-color); }
+  tbody tr { cursor:pointer; }
+  td.code { font-family:var(--bs-font-monospace); color:var(--bs-secondary-color); }
+  td.code .cp { visibility:hidden; margin-left:6px; opacity:.7; }
+  tr:hover td.code { color:var(--fw-code); }
+  tr:hover td.code .cp { visibility:visible; }
+  td.code .cp:hover { opacity:1; }
+  #cd { position:fixed; width:230px; max-height:min(420px,70vh); overflow:auto; z-index:1050; font-size:12px; }
+  #cd .form-check { margin-bottom:0; padding:2px 4px 2px 1.6rem; border-radius:4px; }
+  #cd .form-check:hover { background:var(--bs-tertiary-bg); }
+  #modal { position:fixed; inset:0; background:rgba(0,0,0,.85); display:none;
+           align-items:center; justify-content:center; z-index:1060; padding:24px; }
+  #modal.on { display:flex; }
+  #modal .mcard { max-width:100%; max-height:92vh; overflow:auto; }
+  #modal img { max-width:100%; max-height:86vh; border-radius:8px; display:block; }
+  #modal .mhead { display:flex; align-items:baseline; gap:10px; flex-wrap:wrap; margin-bottom:8px; }
+  #hint { position:fixed; bottom:16px; left:50%; transform:translateX(-50%);
+          z-index:1070; opacity:0; transition:opacity .18s; pointer-events:none; }
+  #hint.on { opacity:1; }

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en" data-bs-theme="dark">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>__TITLE__</title>
+__BOOTSTRAP__
+<link rel="stylesheet" href="/static/css/app.css">
+</head>
+<body class="bg-body">
+<div class="fw-head bg-body border-bottom px-3 pt-3 pb-2">
+  <div class="d-flex align-items-baseline gap-2">
+    <h1 class="h6 mb-0 fw-semibold" id="brand"></h1>
+    <small class="text-secondary" id="src">__SOURCE__</small>
+  </div>
+  <div class="d-flex flex-wrap align-items-center gap-2 mt-2">
+    <input type="search" id="q" class="form-control form-control-sm w-auto"
+           style="min-width:260px">
+    <div class="btn-group btn-group-sm" id="sheets"></div>
+    <div class="btn-group btn-group-sm" id="levels"></div>
+    <button id="cols" class="btn btn-sm btn-outline-secondary"></button>
+    <button id="clear" class="btn btn-sm btn-outline-primary d-none"></button>
+    <span class="ms-auto small text-secondary" id="count"></span>
+  </div>
+</div>
+
+<div class="fw-wrap">
+  <table class="table table-sm table-hover align-middle">
+    <thead><tr id="head"></tr></thead>
+    <tbody id="body"></tbody>
+  </table>
+</div>
+
+<div id="dd" class="dropdown-menu shadow p-2"></div>
+<div id="cd" class="dropdown-menu shadow p-2"></div>
+<div id="modal"><div class="mcard"></div></div>
+<div id="hint"><span class="badge text-bg-secondary rounded-pill px-3 py-2"></span></div>
+
+<script type="application/json" id="fw-boot">__BOOT__</script>
+<script type="module" src="/static/js/main.js"></script>
+</body>
+</html>

--- a/web/static/js/boot.js
+++ b/web/static/js/boot.js
@@ -1,0 +1,19 @@
+// Server-injected data, parsed once from the JSON island in index.html.
+// Re-exported under the names the rest of the page uses.
+const BOOT = JSON.parse(document.getElementById("fw-boot").textContent);
+
+export const DATA = BOOT.data;
+export const LABELS = BOOT.labels;
+export const HELP = BOOT.help;
+export const UI = BOOT.ui;
+export const SCALED = new Set(BOOT.scaled);
+export const TIMECOLS = new Set(BOOT.timecols);
+export const MISSING = BOOT.missing;
+export const MISS_TEXT = BOOT.missText;
+export const MISS_HELP = BOOT.missHelp;
+
+export const LEVELS = ["Expert", "Hard", "Medium", "Easy"];
+
+// Numeric columns with more distinct values than this get a min/max box
+// instead of a checkbox list.
+export const RANGE_MIN_DISTINCT = 25;

--- a/web/static/js/chips.js
+++ b/web/static/js/chips.js
@@ -1,0 +1,11 @@
+// The button-group renderer shared by the sheet row and the level row.
+import { el, esc } from "./dom.js";
+
+export function chips(hostId, items, active, onPick) {
+  el(hostId).innerHTML = items.map(v =>
+    '<button type="button" class="btn btn-fw btn-outline-secondary' +
+    (v === active ? " active" : "") + '" data-v="' + esc(v) + '">' +
+    esc(v) + "</button>").join("");
+  el(hostId).querySelectorAll("button")
+    .forEach(b => b.onclick = () => onPick(b.dataset.v));
+}

--- a/web/static/js/chooser.js
+++ b/web/static/js/chooser.js
@@ -1,0 +1,44 @@
+// The column show/hide panel.
+import { UI } from "./boot.js";
+import { el, esc, placeUnder } from "./dom.js";
+import { lab } from "./format.js";
+import { state, cols, saveHidden } from "./state.js";
+import { draw } from "./table.js";
+
+function renderCD() {
+  const items = cols().map(c =>
+    '<div class="form-check"><input class="form-check-input" type="checkbox" id="cc' +
+    esc(c) + '" data-col="' + esc(c) + '"' + (state.hidden.has(c) ? "" : " checked") + '>' +
+    '<label class="form-check-label" for="cc' + esc(c) + '">' + esc(lab(c)) +
+    "</label></div>").join("");
+  el("cd").innerHTML = items +
+    '<button class="btn btn-sm btn-outline-secondary w-100 mt-2" data-act="showall">' +
+    esc(UI.columns_reset) + "</button>";
+}
+
+export function toggleCD(anchor) {
+  const cd = el("cd");
+  if (cd.classList.contains("show")) { cd.classList.remove("show"); return; }
+  renderCD();
+  cd.classList.add("show");
+  placeUnder(cd, anchor);
+}
+
+export const closeCD = () => el("cd").classList.remove("show");
+
+export function initChooser() {
+  el("cd").addEventListener("change", e => {
+    if (e.target.type !== "checkbox") return;
+    const col = e.target.dataset.col;
+    if (e.target.checked) state.hidden.delete(col); else state.hidden.add(col);
+    saveHidden();
+    draw();
+  });
+  el("cd").addEventListener("click", e => {
+    if (e.target.dataset.act !== "showall") return;
+    state.hidden.clear();
+    saveHidden();
+    draw();
+    renderCD();
+  });
+}

--- a/web/static/js/dom.js
+++ b/web/static/js/dom.js
@@ -1,0 +1,13 @@
+// The two DOM primitives every other module builds on.
+
+export const el = id => document.getElementById(id);
+
+export const esc = v => String(v)
+  .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/"/g, "&quot;");
+
+// Drop a panel just under its anchor, kept inside the viewport.
+export function placeUnder(panel, anchor) {
+  const box = anchor.getBoundingClientRect();
+  panel.style.left = Math.min(box.left, window.innerWidth - panel.offsetWidth - 10) + "px";
+  panel.style.top = (box.bottom + 4) + "px";
+}

--- a/web/static/js/dropdown.js
+++ b/web/static/js/dropdown.js
@@ -1,0 +1,64 @@
+// The per-column filter panel: a min/max box for wide numeric columns,
+// a checkbox list otherwise.
+import { el, placeUnder } from "./dom.js";
+import { rangeBody, checkboxBody } from "./dropdown_view.js";
+import { distinct, useRange } from "./query.js";
+import { state } from "./state.js";
+import { draw } from "./table.js";
+
+function renderDD(query) {
+  const col = state.ddCol;
+  el("dd").innerHTML = useRange(col) ? rangeBody(col) : checkboxBody(col, query);
+  const box = el("ddq");
+  if (box) { box.oninput = () => renderDD(box.value); box.focus(); }
+}
+
+export function openDD(col, anchor) {
+  state.ddCol = col;
+  const dd = el("dd");
+  dd.classList.add("show");
+  renderDD("");
+  placeUnder(dd, anchor);
+}
+
+export function closeDD() {
+  state.ddCol = null;
+  el("dd").classList.remove("show");
+}
+
+// Every value checked is the same as no filter at all.
+function applyChecked() {
+  const boxes = [...el("dd").querySelectorAll("input[type=checkbox]")];
+  const picked = new Set(boxes.filter(b => b.checked).map(b => b.dataset.v));
+  if (picked.size === distinct(state.ddCol).length) delete state.filters[state.ddCol];
+  else state.filters[state.ddCol] = { type: "set", sel: picked };
+  draw();
+}
+
+function applyRange() {
+  const lo = el("ddLo").value, hi = el("ddHi").value;
+  if (lo === "" && hi === "") delete state.filters[state.ddCol];
+  else state.filters[state.ddCol] = {
+    type: "range", lo: lo === "" ? null : +lo, hi: hi === "" ? null : +hi,
+  };
+  draw();
+  closeDD();
+}
+
+const ACTIONS = {
+  all:   () => { delete state.filters[state.ddCol]; draw(); renderDD(""); },
+  none:  () => { state.filters[state.ddCol] = { type: "set", sel: new Set() };
+                 draw(); renderDD(""); },
+  clear: () => { delete state.filters[state.ddCol]; draw(); closeDD(); },
+  apply: applyRange,
+};
+
+export function initDropdown() {
+  el("dd").addEventListener("change", e => {
+    if (e.target.type === "checkbox") applyChecked();
+  });
+  el("dd").addEventListener("click", e => {
+    const act = ACTIONS[e.target.dataset.act];
+    if (act) act();
+  });
+}

--- a/web/static/js/dropdown_view.js
+++ b/web/static/js/dropdown_view.js
@@ -1,0 +1,60 @@
+// The two bodies the filter panel can show: a min/max box, or a value list.
+import { UI, MISSING, MISS_TEXT, TIMECOLS } from "./boot.js";
+import { esc } from "./dom.js";
+import { lab, t, mmss, key } from "./format.js";
+import { distinct, passing } from "./query.js";
+import { state, idx, rowsAll } from "./state.js";
+
+// A sentinel reads as the em dash but still matches on its raw key.
+const shown = (col, k) =>
+  (MISSING[col] || []).indexOf(parseFloat(k)) >= 0 ? MISS_TEXT : k;
+
+export function rangeBody(col) {
+  const f = state.filters[col], i = idx(col);
+  const vals = rowsAll().map(r => r[i]).filter(v => typeof v === "number");
+  const lo = Math.min(...vals), hi = Math.max(...vals);
+  const asText = v => TIMECOLS.has(col) ? mmss(v) : v.toFixed(2);
+  const value = k => f && f[k] !== null && f[k] !== undefined ? f[k] : "";
+  return '<div class="input-group input-group-sm">' +
+    '<input type="number" class="form-control" id="ddLo" placeholder="' +
+    esc(t("range_min", { v: asText(lo) })) + '" value="' + value("lo") + '">' +
+    '<span class="input-group-text">&ndash;</span>' +
+    '<input type="number" class="form-control" id="ddHi" placeholder="' +
+    esc(t("range_max", { v: asText(hi) })) + '" value="' + value("hi") + '"></div>' +
+    '<div class="d-flex gap-2 mt-2">' +
+    '<button class="btn btn-sm btn-primary flex-fill" data-act="apply">' +
+    esc(UI.range_apply) + '</button>' +
+    '<button class="btn btn-sm btn-outline-secondary flex-fill" data-act="clear">' +
+    esc(UI.range_clear) + '</button></div>' +
+    '<div class="form-text mt-2">' + esc(t("range_hint", { label: lab(col) })) + '</div>';
+}
+
+export function checkboxBody(col, query) {
+  const all = distinct(col);
+  const matches = query
+    ? all.filter(v => shown(col, v).toLowerCase().includes(query.toLowerCase()) ||
+                      v.toLowerCase().includes(query.toLowerCase()))
+    : all;
+  const f = state.filters[col], i = idx(col), counts = {};
+  passing(col).forEach(r => {
+    const k = key(r[i]);
+    counts[k] = (counts[k] || 0) + 1;
+  });
+  const search = all.length > 12
+    ? '<input type="search" class="form-control form-control-sm mb-2" id="ddq" ' +
+      'placeholder="' + esc(UI.value_search) + '" value="' + esc(query) + '">'
+    : "";
+  const items = matches.map(v =>
+    '<div class="form-check"><input class="form-check-input" type="checkbox" id="cb' +
+    esc(v) + '" data-v="' + esc(v) + '"' + (!f || f.sel.has(v) ? " checked" : "") + '>' +
+    '<label class="form-check-label" for="cb' + esc(v) + '"><span class="v">' +
+    esc(shown(col, v)) + '</span><span class="n">' + (counts[v] || 0) +
+    "</span></label></div>").join("");
+  return search +
+    '<div class="d-flex gap-2 mb-2">' +
+    '<button class="btn btn-sm btn-outline-secondary flex-fill" data-act="all">' +
+    esc(UI.select_all) + '</button>' +
+    '<button class="btn btn-sm btn-outline-secondary flex-fill" data-act="none">' +
+    esc(UI.select_none) + '</button></div>' +
+    '<div class="list">' + items + "</div>";
+}

--- a/web/static/js/format.js
+++ b/web/static/js/format.js
@@ -1,0 +1,22 @@
+// Turning a stored value into the text a person reads.
+import { LABELS, UI, MISSING, MISS_TEXT } from "./boot.js";
+
+// Display label for a column key; unknown keys fall back to the key itself.
+export const lab = c => LABELS[c] || c;
+
+// UI string with {placeholders} filled from vars.
+export const t = (k, vars) => (UI[k] || k)
+  .replace(/\{(\w+)\}/g, (_, name) => vars && name in vars ? vars[name] : "");
+
+// Seconds as m:ss.
+export const mmss = secs => {
+  const whole = Math.max(0, Math.round(secs));
+  return Math.floor(whole / 60) + ":" + String(whole % 60).padStart(2, "0");
+};
+
+// Stable string form of a cell value, used as a filter key.
+export const key = v => v === null ? MISS_TEXT : String(v);
+
+// True for null, or for a column's own "unrated" sentinel.
+export const isMissing = (col, v) =>
+  v === null || (MISSING[col] || []).indexOf(v) >= 0;

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -1,0 +1,25 @@
+// Entry module: label the chrome, wire the panels, then first paint.
+import { UI } from "./boot.js";
+import { el, esc } from "./dom.js";
+import { initDropdown } from "./dropdown.js";
+import { initChooser } from "./chooser.js";
+import { initRouter, render } from "./router.js";
+import { state } from "./state.js";
+
+function labelChrome() {
+  el("brand").innerHTML = esc(UI.title) +
+    ' <span class="fw-accent">&#9679;</span> <span class="fw-normal">' +
+    esc(UI.subtitle) + "</span>";
+  el("q").placeholder = UI.search;
+  el("cols").textContent = UI.columns;
+  el("cols").title = UI.columns_tip;
+}
+
+labelChrome();
+initDropdown();
+initChooser();
+initRouter();
+
+// Open on Expert only; the chips read this back as their active state.
+state.filters["Level"] = { type: "set", sel: new Set(["Expert"]) };
+render();

--- a/web/static/js/markup.js
+++ b/web/static/js/markup.js
@@ -1,0 +1,56 @@
+// Builds the table's HTML. Everything it needs is passed in.
+import { SCALED, TIMECOLS, HELP, UI, MISS_TEXT, MISS_HELP } from "./boot.js";
+import { esc } from "./dom.js";
+import { lab, mmss, isMissing } from "./format.js";
+import { scaleColor } from "./scale.js";
+
+export function headerCell(col, { sorted, ascending, filtered }) {
+  const cls = [sorted ? "sorted" : "", filtered ? "filtered" : ""].join(" ").trim();
+  const tip = (HELP[col] ? HELP[col] + "\n\n" : "") + "Column: " + col + "\n" + UI.sort_tip;
+  const arrow = sorted ? (ascending ? " &#9650;" : " &#9660;") : "";
+  return '<th data-c="' + esc(col) + '"' + (cls ? ' class="' + cls + '"' : '') +
+    '><div class="thw">' +
+    '<span class="lbl" data-sort="' + esc(col) + '" title="' + esc(tip) + '">' +
+    esc(lab(col)) + arrow + '</span>' +
+    '<button class="btn btn-sm btn-link p-0 px-1 flt text-secondary" data-flt="' +
+    esc(col) + '" title="' + esc(UI.filter_tip) + '">&#9662;</button></div></th>';
+}
+
+function numberCell(col, v, bounds) {
+  const text = Number.isInteger(v) ? v : v.toFixed(2);
+  if (!SCALED.has(col) || !bounds) return '<td class="num">' + text + "</td>";
+  return '<td class="num"><span class="scale" style="background:' +
+    scaleColor(v, bounds[0], bounds[1]) + '">' + text + "</span></td>";
+}
+
+function bodyCell(col, v, bounds) {
+  if (col === "Code")
+    return '<td class="code" title="' + esc(UI.copy_code_tip) + '">' + esc(v) +
+      '<span class="cp" data-copy="' + esc(v) + '">&#128203;</span></td>';
+  if (col === "Level")
+    return '<td><span class="badge rounded-pill lvl ' + esc(v) + '">' + esc(v) + "</span></td>";
+  if (col === "Song Title" || col === "Artist")
+    return '<td class="title" title="' + esc(v ?? "") + '">' + esc(v ?? "") + "</td>";
+  if (isMissing(col, v)) {
+    const tip = MISS_HELP[col] || "";
+    return '<td class="num blank"' + (tip ? ' title="' + esc(tip) + '"' : '') +
+      ">" + MISS_TEXT + "</td>";
+  }
+  if (TIMECOLS.has(col) && typeof v === "number")
+    return '<td class="num">' + mmss(v) + "</td>";
+  if (typeof v === "number") return numberCell(col, v, bounds);
+  return "<td>" + esc(v === null ? "" : v) + "</td>";
+}
+
+export function bodyRow(row, visibleCols, code, bounds) {
+  const cells = visibleCols
+    .map(([col, i]) => bodyCell(col, row[i], bounds[col]))
+    .join("");
+  return '<tr title="' + esc(UI.row_tip) + '" data-code="' + esc(code) + '">' +
+    cells + "</tr>";
+}
+
+export function emptyRow(span) {
+  return '<tr><td colspan="' + span + '" class="text-secondary p-3">' +
+    esc(UI.no_data) + "</td></tr>";
+}

--- a/web/static/js/overlay.js
+++ b/web/static/js/overlay.js
@@ -1,0 +1,45 @@
+// The graph lightbox and the transient hint, the page's two overlays.
+import { UI } from "./boot.js";
+import { el, esc } from "./dom.js";
+import { cols, rowsAll } from "./state.js";
+
+let hintTimer = null;
+
+export function toast(message) {
+  const hint = el("hint");
+  hint.firstElementChild.textContent = message;
+  hint.classList.add("on");
+  clearTimeout(hintTimer);
+  hintTimer = setTimeout(() => hint.classList.remove("on"), 1400);
+}
+
+// Names the chart being shown, so the graph is never unlabelled.
+function heading(code) {
+  const columns = cols();
+  const row = rowsAll().find(r => r[columns.indexOf("Code")] === code);
+  const get = name => {
+    const i = columns.indexOf(name);
+    return i < 0 || row === undefined ? "" : row[i];
+  };
+  return '<div class="mhead"><strong>' + esc(get("Song Title")) + '</strong>' +
+    '<span class="text-secondary">' + esc(get("Artist")) + '</span>' +
+    '<span class="badge rounded-pill lvl ' + esc(get("Level")) + '">' +
+    esc(get("Level")) + '</span>' +
+    '<span class="text-secondary">' + esc(get("Type")) + '</span></div>';
+}
+
+export function openGraph(code) {
+  const modal = el("modal"), card = modal.querySelector(".mcard");
+  const head = heading(code);
+  const message = text => head + '<div class="text-secondary py-4">' + esc(text) + "</div>";
+
+  modal.classList.add("on");
+  card.innerHTML = message(UI.rendering);
+
+  const img = new Image();
+  img.onload = () => { card.innerHTML = head; card.appendChild(img); };
+  img.onerror = () => { card.innerHTML = message(UI.render_failed); };
+  img.src = "/graph/" + code + ".png";
+}
+
+export const closeGraph = () => el("modal").classList.remove("on");

--- a/web/static/js/query.js
+++ b/web/static/js/query.js
@@ -1,0 +1,64 @@
+// Selecting and ordering rows: what the active filters and sort resolve to.
+import { RANGE_MIN_DISTINCT } from "./boot.js";
+import { el } from "./dom.js";
+import { isMissing, key } from "./format.js";
+import { state, cols, idx, rowsAll } from "./state.js";
+
+const SEARCH_COLS = ["Song Title", "Artist", "Charter", "Release", "Code"];
+
+function isNumeric(col) {
+  const i = idx(col);
+  return rowsAll().some(r => typeof r[i] === "number") &&
+         rowsAll().every(r => r[i] === null || typeof r[i] === "number");
+}
+
+// Every distinct value in a column, numerically ordered where possible.
+export function distinct(col) {
+  const i = idx(col);
+  return [...new Set(rowsAll().map(r => key(r[i])))].sort((a, b) => {
+    const x = parseFloat(a), y = parseFloat(b);
+    return !isNaN(x) && !isNaN(y) ? x - y : a.localeCompare(b);
+  });
+}
+
+// A min/max box suits a numeric column with too many values to list.
+export const useRange = col =>
+  isNumeric(col) && distinct(col).length > RANGE_MIN_DISTINCT;
+
+function matchesSearch(row, columns) {
+  const q = el("q").value.trim().toLowerCase();
+  if (!q) return true;
+  return SEARCH_COLS.map(n => columns.indexOf(n)).filter(i => i >= 0)
+    .some(i => String(row[i] ?? "").toLowerCase().includes(q));
+}
+
+function matchesFilter(row, columns, col, filter) {
+  const i = columns.indexOf(col);
+  if (i < 0) return true;
+  const v = row[i];
+  if (filter.type === "set") return filter.sel.has(key(v));
+  if (typeof v !== "number") return false;
+  return (filter.lo === null || v >= filter.lo) &&
+         (filter.hi === null || v <= filter.hi);
+}
+
+// Rows passing the search and every filter except exceptCol, so a dropdown
+// can count values in the context of the other active filters.
+export function passing(exceptCol) {
+  const columns = cols();
+  return rowsAll().filter(row =>
+    matchesSearch(row, columns) &&
+    Object.entries(state.filters).every(([col, f]) =>
+      col === exceptCol || matchesFilter(row, columns, col, f)));
+}
+
+// Missing values sort last in both directions.
+export function compare(a, b) {
+  const am = isMissing(state.sortCol, a), bm = isMissing(state.sortCol, b);
+  if (am || bm) return am && bm ? 0 : (am ? 1 : -1);
+  if (typeof a === "number" && typeof b === "number")
+    return state.sortAsc ? a - b : b - a;
+  return state.sortAsc
+    ? String(a).localeCompare(String(b))
+    : String(b).localeCompare(String(a));
+}

--- a/web/static/js/router.js
+++ b/web/static/js/router.js
@@ -1,0 +1,74 @@
+// The one document-level click handler. Order is behaviour: each branch
+// returns so a more specific target wins over the row click beneath it.
+import { DATA } from "./boot.js";
+import { chips } from "./chips.js";
+import { el } from "./dom.js";
+import { t } from "./format.js";
+import { openDD, closeDD } from "./dropdown.js";
+import { toggleCD, closeCD } from "./chooser.js";
+import { openGraph, closeGraph, toast } from "./overlay.js";
+import { state, idx } from "./state.js";
+import { draw } from "./table.js";
+
+function sortBy(col) {
+  if (col === state.sortCol) state.sortAsc = !state.sortAsc;
+  else { state.sortCol = col; state.sortAsc = false; }
+  draw();
+}
+
+function copyCode(event, cell) {
+  event.stopPropagation();
+  navigator.clipboard?.writeText(cell.dataset.copy);
+  toast(t("copied", { code: cell.dataset.copy }));
+}
+
+function onClick(e) {
+  if (e.target.closest("#dd") || e.target.closest("#cd")) return;
+
+  if (e.target.closest("#cols")) { closeDD(); toggleCD(el("cols")); return; }
+  closeCD();
+
+  const flt = e.target.closest("[data-flt]");
+  if (flt) {
+    const col = flt.dataset.flt;
+    if (state.ddCol === col) closeDD(); else openDD(col, flt.closest("th"));
+    return;
+  }
+  closeDD();
+
+  const label = e.target.closest("[data-sort]");
+  if (label) { sortBy(label.dataset.sort); return; }
+
+  const pip = e.target.closest("[data-copy]");
+  if (pip) { copyCode(e, pip); return; }
+
+  const row = e.target.closest("tbody tr[data-code]");
+  if (row) { openGraph(row.dataset.code); return; }
+
+  if (e.target.closest("#modal")) closeGraph();
+}
+
+function onKeydown(e) {
+  if (e.key !== "Escape") return;
+  closeDD();
+  closeCD();
+  closeGraph();
+}
+
+// Repaint the sheet chips too, since switching sheets re-enters here.
+export function render() {
+  chips("sheets", Object.keys(DATA), state.sheet, v => {
+    state.sheet = v;
+    state.filters = {};
+    if (idx(state.sortCol) < 0) state.sortCol = "D";
+    render();
+  });
+  draw();
+}
+
+export function initRouter() {
+  document.addEventListener("click", onClick);
+  document.addEventListener("keydown", onKeydown);
+  el("q").addEventListener("input", draw);
+  el("clear").addEventListener("click", () => { state.filters = {}; draw(); });
+}

--- a/web/static/js/scale.js
+++ b/web/static/js/scale.js
@@ -1,0 +1,28 @@
+// The green-yellow-red ramp shared with the spreadsheet's colour scale.
+import { SCALED } from "./boot.js";
+import { isMissing } from "./format.js";
+import { cols } from "./state.js";
+
+const LOW = [198, 239, 206], MID = [255, 235, 156], HIGH = [255, 199, 206];
+
+// Position v within [lo, hi] on the ramp.
+export function scaleColor(v, lo, hi) {
+  const ratio = hi === lo ? 0.5 : Math.max(0, Math.min(1, (v - lo) / (hi - lo)));
+  const [from, to, step] = ratio < 0.5
+    ? [LOW, MID, ratio * 2]
+    : [MID, HIGH, (ratio - 0.5) * 2];
+  const mix = from.map((n, i) => Math.round(n + (to[i] - n) * step));
+  return "rgb(" + mix.join(",") + ")";
+}
+
+// Min/max per scaled column across the given rows, ignoring missing values.
+export function ranges(rows) {
+  const out = {}, columns = cols();
+  SCALED.forEach(c => {
+    const i = columns.indexOf(c);
+    if (i < 0) return;
+    const vals = rows.map(r => r[i]).filter(v => !isMissing(c, v));
+    if (vals.length) out[c] = [Math.min(...vals), Math.max(...vals)];
+  });
+  return out;
+}

--- a/web/static/js/state.js
+++ b/web/static/js/state.js
@@ -1,0 +1,33 @@
+// All mutable page state, in one object because ES module imports are
+// read-only bindings and several of these are reassigned wholesale.
+import { DATA } from "./boot.js";
+
+const STORAGE_KEY = "fw.hidden";
+
+function loadHidden() {
+  try { return new Set(JSON.parse(localStorage.getItem(STORAGE_KEY) || "[]")); }
+  catch (e) { return new Set(); }
+}
+
+export const state = {
+  sheet: Object.keys(DATA)[0],
+  sortCol: "D",
+  sortAsc: false,
+  filters: {},        // column -> {type:"set", sel:Set} | {type:"range", lo, hi}
+  ddCol: null,        // column whose filter dropdown is open
+  hidden: loadHidden(),
+};
+
+// Remember hidden columns per browser; storage may be unavailable.
+export function saveHidden() {
+  try { localStorage.setItem(STORAGE_KEY, JSON.stringify([...state.hidden])); }
+  catch (e) {}
+}
+
+export const cols = () => DATA[state.sheet].columns;
+export const rowsAll = () => DATA[state.sheet].rows;
+export const idx = name => cols().indexOf(name);
+
+// [column, index-into-row] for every column still on screen.
+export const visible = () =>
+  cols().map((c, i) => [c, i]).filter(([c]) => !state.hidden.has(c));

--- a/web/static/js/table.js
+++ b/web/static/js/table.js
@@ -1,0 +1,51 @@
+// One repaint: filter, sort, render, then refresh the footer and level chips.
+import { LEVELS, UI } from "./boot.js";
+import { chips } from "./chips.js";
+import { el } from "./dom.js";
+import { t } from "./format.js";
+import { headerCell, bodyRow, emptyRow } from "./markup.js";
+import { passing, compare } from "./query.js";
+import { ranges } from "./scale.js";
+import { state, cols, idx, rowsAll, visible } from "./state.js";
+
+function paintFooter(shown, total) {
+  el("count").textContent = t("count", { shown: shown, total: total });
+  const n = Object.keys(state.filters).length;
+  const clear = el("clear");
+  clear.textContent = n === 1 ? UI.clear_one : t("clear_many", { n: n });
+  clear.classList.toggle("d-none", n === 0);
+}
+
+// The level chips are a shortcut into the Level column filter, so they read
+// their active state back out of it.
+function paintLevelChips() {
+  const f = state.filters["Level"];
+  const active = f && f.type === "set" && f.sel.size === 1 ? [...f.sel][0] : null;
+  chips("levels", LEVELS, active, v => {
+    if (active === v) delete state.filters["Level"];
+    else state.filters["Level"] = { type: "set", sel: new Set([v]) };
+    draw();
+  });
+}
+
+export function draw() {
+  const vis = visible();
+  const sortIdx = idx(state.sortCol);
+  const rows = passing(null);
+  if (sortIdx >= 0) rows.sort((a, b) => compare(a[sortIdx], b[sortIdx]));
+
+  el("head").innerHTML = vis.map(([c]) => headerCell(c, {
+    sorted: c === state.sortCol,
+    ascending: state.sortAsc,
+    filtered: Boolean(state.filters[c]),
+  })).join("");
+
+  const bounds = ranges(rows);
+  const codeIdx = cols().indexOf("Code");
+  el("body").innerHTML = rows.length
+    ? rows.map(r => bodyRow(r, vis, r[codeIdx], bounds)).join("")
+    : emptyRow(vis.length);
+
+  paintFooter(rows.length, rowsAll().length);
+  paintLevelChips();
+}


### PR DESCRIPTION
Adds an optional fourth step alongside Build/Analyze/Render: a local web page for browsing the metrics spreadsheet without opening Excel.

`python serve.py` reads the newest metrics `.xlsx` for your header and serves it on `localhost:8000` as a sortable, filterable table. Clicking a row renders that chart's graph on demand — the same PNG `render.py` produces, written to your render folder.

### Screenshots

The table, sorted by D with the Expert filter on by default:

![Table view](https://raw.githubusercontent.com/ChaseFranz/fretwork/screenshots/table.png)

Filtering a column. Counts reflect the other active filters:

![Column filter](https://raw.githubusercontent.com/ChaseFranz/fretwork/screenshots/filter.png)

Choosing which columns to show, remembered per browser:

![Column chooser](https://raw.githubusercontent.com/ChaseFranz/fretwork/screenshots/columns.png)

Clicking a row renders that chart's graph:

![Graph lightbox](https://raw.githubusercontent.com/ChaseFranz/fretwork/screenshots/graph.png)

### What the page does

- Sort by any column, click again to flip. Opens sorted by D, hardest first
- Excel-style filter dropdown per column: a checkbox list with live value counts for things like Part or Remap Tier, a min/max box for wide numeric columns like D or Length
- Free-text search across song, artist, charter and source
- Click a row for its difficulty graph in a lightbox; the copy icon on a Code cell copies the retrieval code instead
- Hide any column you don't want, remembered in the browser
- Friendly column names with the metric definitions on hover. Unrated songs (`diff_*` of -1) show a dash instead of the raw number

### Notes for review

**No new dependencies.** Stdlib `http.server` plus pandas, which the project already requires. `requirements.txt` is untouched.

**Binds `127.0.0.1` only.** Read-only: it serves the spreadsheet and renders PNGs, and never writes to `song.ini`.

**Bootstrap supplies the CSS**, downloaded once into `CACHE_DIR` and then served same-origin, so the page never contacts a CDN at view time and works offline after the first run. `--no-bootstrap`, or a failed fetch, falls back to built-in styles.

**Layout.** `serve.py` stays a thin entry point in the same shape as the other three (docstring, one orchestration function, `main()`). The rest lives in `web/`, a namespace package like `functions/` and `parsers/`. It is named `web/` rather than `serve/` because a `serve/` directory beside `serve.py` loses to the module in Python's import resolution and would be silently unimportable. The page's markup, CSS and 15 ES modules live under `web/static/` as real files rather than inside a Python string.

**matplotlib and openpyxl stay off the server's startup path**, so launching the viewer is fast. `GraphRenderer` imports `plot` inside its method bodies, and `web/boot.py` keeps a local copy of `SCALED_COLS` rather than importing `xlsx_format` for it.

### Two changes outside the new code

`functions/difficulty.py` extracts the per-entry difficulty block that was duplicated verbatim between `render.py` and the viewer. `render.py` now calls it. I verified this produces **byte-identical PNGs** for four codes across Guitar, Rhythm and Bass, with the `with_difficulty=False` path still working.

`functions/labels.py` holds the display labels, tooltips and UI strings, so the abbreviated column keys (`pNPS`, `medVPS`, `COV`) stay data-only and never reach a reader. Only the viewer consumes it today; `xlsx_format` and `plot` could adopt it later without a pipeline rename.

`.gitignore` gains `.venv/` and `songs/`.

### Testing

Verified against a 75-song GH3 library. Build, Analyze and Render are unaffected. Also checked: the `--no-bootstrap` and offline-first-run fallbacks, `/graph/../../etc/passwd` rejected with a 400, and a song title containing `</script>` no longer able to break out of the page.

Happy to split this up, drop `CLAUDE.md`, or revert the `render.py` change if you'd rather keep that file untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
